### PR TITLE
Features/code quality

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel'}
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-20.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest", http-user-agent: "R/4.0.0 (ubuntu-16.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
@@ -61,7 +60,8 @@ jobs:
           while read -r cmd
           do
             eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "16.04"))')
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)

--- a/R/ComboGrid.R
+++ b/R/ComboGrid.R
@@ -58,12 +58,15 @@ comboGrid <- function(..., repetition = TRUE) {
 
     if (length(idx_nas)) {
         res <- as.data.frame(res)
+        names(res) <- nmc[setdiff(iArgs, idx_nas)]
 
         for (idx in idx_nas) {
-            res[, nmc[idx]] <- NA
+            res[nmc[idx]] <- NA
         }
 
         res <- res[, nmc]
+    } else if (is.matrix(res)) {
+        colnames(res) <- nmc
     }
 
     return(res)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -216,7 +216,7 @@
         \item {Added gmp support to combinatorial functions. Now, one can accurately and quickly work with combinations/permutations of large vectors \emph{E.g.}:
             \itemize{
                 \item \code{comboSample(runif(10000), 100, n = 10, seed = 42, Parallel = TRUE)}
-                \item \code{permuteGeneral(factor(state.name), 20, 
+                \item \code{permuteGeneral(factor(state.name), 20,
                             lower = 1e15, upper = 1e15 + 1000)}
             }
         }
@@ -345,5 +345,3 @@
         \item Initial Release
     }
 }
-
-

--- a/inst/include/CleanConvert.h
+++ b/inst/include/CleanConvert.h
@@ -3,6 +3,7 @@
 
 #include "cpp11/R.hpp"
 #include "cpp11/protect.hpp"
+#include "cpp11/sexp.hpp"
 
 #include <limits>
 #include <vector>
@@ -36,8 +37,7 @@ namespace CleanConvert {
     template <typename T>
     std::vector<T> GetNumVec(SEXP Rv);
 
-    SEXP GetCount(bool IsGmp, const mpz_t computedRowsMpz,
-                  double computedRows);
+    SEXP GetCount(bool IsGmp, const mpz_t numMpz, double numDbl);
 
     bool convertFlag(SEXP boolInput, const std::string &nameOfBool);
 
@@ -45,7 +45,8 @@ namespace CleanConvert {
     void convertPrimitive(SEXP input, T &result, VecType myType,
                           const std::string &nameOfObject,
                           bool numOnly = true, bool checkWhole = true,
-                          bool negPoss = false, bool decimalFraction = false);
+                          bool negPoss = false,
+                          bool decimalFraction = false);
 
     template <typename T>
     void convertVector(SEXP input, std::vector<T> &result,

--- a/src/CartesianContainer.cpp
+++ b/src/CartesianContainer.cpp
@@ -1,3 +1,10 @@
+#include "cpp11/logicals.hpp"
+#include "cpp11/integers.hpp"
+#include "cpp11/doubles.hpp"
+#include "cpp11/strings.hpp"
+#include "cpp11/matrix.hpp"
+#include "cpp11/list.hpp"
+
 #include "NumbersUtils/Eratosthenes.h"
 #include "ComboCartesian.h"
 #include "CleanConvert.h"
@@ -21,15 +28,14 @@ void convertToString(std::vector<std::string> &tempVec,
     switch(TYPEOF(ListElement)) {
         case INTSXP: {
             if (bFac) {
-                SEXP facVec = PROTECT(Rf_coerceVector(ListElement, INTSXP));
-                SEXP myLevels = PROTECT(Rf_getAttrib(facVec, R_LevelsSymbol));
+                cpp11::integers facVec(ListElement);
+                cpp11::strings myLevels(facVec.attr("levels"));
                 std::vector<std::string> strVec;
 
                 for (int i = 0, faclen = Rf_length(myLevels); i < faclen; ++i) {
-                    strVec.push_back(CHAR(STRING_ELT(myLevels, i)));
+                    strVec.push_back(myLevels[i]);
                 }
 
-                UNPROTECT(2);
                 typePass = tFac;
 
                 for (auto v: strVec) {
@@ -47,8 +53,7 @@ void convertToString(std::vector<std::string> &tempVec,
                     tempVec.push_back(v);
                 }
             } else {
-                int* intPtr = INTEGER(ListElement);
-                std::vector<int> intVec(intPtr, intPtr + len);
+                cpp11::integers intVec(ListElement);
                 typePass = tInt;
 
                 for (auto v: intVec) {
@@ -58,8 +63,7 @@ void convertToString(std::vector<std::string> &tempVec,
 
             break;
         } case LGLSXP: {
-            int* intPtr = INTEGER(ListElement);
-            std::vector<int> intVec(intPtr, intPtr + len);
+            cpp11::integers intVec(ListElement);
             typePass = tLog;
 
             for (auto v: intVec) {
@@ -69,8 +73,7 @@ void convertToString(std::vector<std::string> &tempVec,
 
             break;
         } case REALSXP: {
-            double* dblPtr = REAL(ListElement);
-            std::vector<double> dblVec(dblPtr, dblPtr + len);
+            cpp11::doubles dblVec(ListElement);
             typePass = tDbl;
 
             for (auto v: dblVec) {
@@ -114,72 +117,65 @@ void convertToString(std::vector<std::string> &tempVec,
     }
 }
 
-void AddNames(SEXP res, SEXP RList) {
-    if (!Rf_isNull(Rf_getAttrib(RList, R_NamesSymbol))) {
-        SEXP myNames = PROTECT(Rf_getAttrib(RList, R_NamesSymbol));
-        SEXP dimNames = PROTECT(Rf_allocVector(VECSXP, 2));
-        SET_VECTOR_ELT(dimNames, 1, myNames);
-        Rf_setAttrib(res, R_DimNamesSymbol, dimNames);
-        UNPROTECT(2);
-    }
-}
-
-void GetCharOutput(SEXP res, SEXP RList,
+void GetCharOutput(cpp11::writable::strings_matrix<> &mat,
+                   const cpp11::list &RList,
                    const std::vector<int> &cartCombs,
                    const std::vector<int> &lastCol,
                    const std::vector<int> &lenGrps,
-                   SEXP charVec, int nCols, int nRows) {
+                   const cpp11::strings &charVec, int nCols, int nRows) {
 
-    for (int i = 0, n1 = nCols - 1, row = 0, m_idx = 0,
-         baseSize = lenGrps.size(); i < baseSize; ++i, m_idx = row) {
+    for (int i = 0, n1 = nCols - 1, row = 0,
+         baseSize = lenGrps.size(); i < baseSize; ++i) {
 
         for (int j = 0, c_idx = i * n1, grpSize = lenGrps[i];
-             j < n1; ++j, ++c_idx, m_idx += nRows) {
+             j < n1; ++j, ++c_idx) {
 
-            SEXP comb = PROTECT(STRING_ELT(charVec, cartCombs[c_idx]));
+            auto&& comb = charVec[cartCombs[c_idx]];
 
             for (int k = 0; k < grpSize; ++k) {
-                SET_STRING_ELT(res, m_idx + k, comb);
+                mat(k, j) = comb;
             }
-
-            UNPROTECT(1);
         }
 
         for (int k = 0; k < lenGrps[i]; ++k, ++row) {
-            SET_STRING_ELT(res, m_idx + k,
-                           STRING_ELT(charVec, lastCol[row]));
+            mat(k, n1) = charVec[lastCol[row]];
         }
     }
 
-    AddNames(res, RList);
+    if (RList.named()) mat.attr("colnames") = RList.names();
 }
 
-template <typename T>
-void GetPureOutput(T* mat, SEXP res, SEXP RList,
+template <typename matType, typename T>
+void GetPureOutput(matType &mat, const cpp11::list &RList,
                    const std::vector<int> &cartCombs,
                    const std::vector<int> &lastCol,
                    const std::vector<int> &lenGrps,
-                   const T* standardVec, int nCols, int nRows) {
+                   const std::vector<T> &standardVec,
+                   int nCols, int nRows) {
 
     for (int i = 0, n1 = nCols - 1, row = 0, m_idx = 0,
-         baseSize = lenGrps.size(); i < baseSize; ++i, m_idx = row) {
+         baseSize = lenGrps.size(); i < baseSize; ++i) {
 
         for (int j = 0, c_idx = i * n1, grpSize = lenGrps[i];
-             j < n1; ++j, ++c_idx, m_idx += nRows) {
+             j < n1; ++j, ++c_idx) {
 
             auto&& comb = standardVec[cartCombs[c_idx]];
 
             for (int k = 0; k < grpSize; ++k) {
-                mat[m_idx + k] = comb;
+                mat(m_idx + k, j) = comb;
             }
         }
 
         for (int k = 0; k < lenGrps[i]; ++k, ++row) {
-            mat[m_idx + k] = standardVec[lastCol[row]];
+            mat(m_idx + k, n1) = standardVec[lastCol[row]];
         }
+
+        m_idx += lenGrps[i];
     }
 
-    AddNames(res, RList);
+    if (RList.named()) {
+        mat.attr("colnames") = RList.names();
+    }
 }
 
 SEXP GlueComboCart(const std::vector<int> &cartCombs,
@@ -187,30 +183,27 @@ SEXP GlueComboCart(const std::vector<int> &cartCombs,
                    const std::vector<int> &lenGrps,
                    const std::vector<std::vector<int>> &facList,
                    const std::vector<int> &typeCheck,
-                   const std::vector<int> &IsFactor, SEXP RList,
-                   int* intVec, int* boolVec, double* dblVec,
-                   SEXP charVec, int nRows, int nCols, bool IsDF) {
+                   const std::vector<int> &IsFactor,
+                   const cpp11::list &RList,
+                   const std::vector<int> &intVec,
+                   const std::vector<double> &dblVec,
+                   const std::vector<int> &boolVec,
+                   const cpp11::strings &charVec,
+                   int nRows, int nCols, bool IsDF) {
 
     if (IsDF) {
-        SEXP DataFrame = PROTECT(Rf_allocVector(VECSXP, nCols));
-        int numProtects = 1;
+        cpp11::writable::list DataFrame(nCols);
 
         for (int i = 0, facInd = 0; i < nCols; ++i) {
-            switch (TYPEOF(VECTOR_ELT(RList, i))) {
+            switch (TYPEOF(RList[i])) {
                 case INTSXP: {
-                    SEXP sexpVec = PROTECT(Rf_allocVector(INTSXP, nRows));
-                    int* intSexpVec = INTEGER(sexpVec);
-                    ++numProtects;
+                    cpp11::writable::integers intSexpVec(nRows);
 
                     if (IsFactor[i]) {
-                        const int size = facList[facInd].size();
-                        SEXP facVec = PROTECT(Rf_allocVector(INTSXP, size));
-                        int* intFacVec = INTEGER(facVec);
-                        ++numProtects;
-
-                        for (int j = 0; j < size; ++j) {
-                            intFacVec[j] = facList[facInd][j];
-                        }
+                        const std::vector<int> intFacVec(
+                                facList[facInd].begin(),
+                                facList[facInd].end()
+                        );
 
                         if (i < (nCols - 1)) {
                             for (int j = 0, n1 = nCols - 1, row = i, idx = 0,
@@ -229,7 +222,10 @@ SEXP GlueComboCart(const std::vector<int> &cartCombs,
                             }
                         }
 
-                        SetFactorClass(sexpVec, VECTOR_ELT(RList, i));
+                        // cpp11::integers myLevels(RList[i]);
+                        // intSexpVec.attr("levels") = myLevels.attr("levels");
+                        // intSexpVec.attr("class")  = "factor";
+                        // SetFactorClass(sexpVec, VECTOR_ELT(RList, i));
                         ++facInd;
                     } else {
                         if (i < (nCols - 1)) {
@@ -250,12 +246,10 @@ SEXP GlueComboCart(const std::vector<int> &cartCombs,
                         }
                     }
 
-                    SET_VECTOR_ELT(DataFrame, i, sexpVec);
+                    DataFrame[i] = intSexpVec;
                     break;
                 } case LGLSXP: {
-                    SEXP sexpVec = PROTECT(Rf_allocVector(LGLSXP, nRows));
-                    int* boolSexpVec = INTEGER(sexpVec);
-                    ++numProtects;
+                    cpp11::writable::logicals boolSexpVec(nRows);
 
                     if (i < (nCols - 1)) {
                         for (int j = 0, n1 = nCols - 1, row = i, idx = 0,
@@ -274,12 +268,10 @@ SEXP GlueComboCart(const std::vector<int> &cartCombs,
                         }
                     }
 
-                    SET_VECTOR_ELT(DataFrame, i, sexpVec);
+                    DataFrame[i] = boolSexpVec;
                     break;
                 } case REALSXP: {
-                    SEXP sexpVec = PROTECT(Rf_allocVector(REALSXP, nRows));
-                    double* dblSexpVec = REAL(sexpVec);
-                    ++numProtects;
+                    cpp11::writable::doubles dblSexpVec(nRows);
 
                     if (i < (nCols - 1)) {
                         for (int j = 0, n1 = nCols - 1, row = i, idx = 0,
@@ -298,85 +290,64 @@ SEXP GlueComboCart(const std::vector<int> &cartCombs,
                         }
                     }
 
-                    SET_VECTOR_ELT(DataFrame, i, sexpVec);
+                    DataFrame[i] = dblSexpVec;
                     break;
                 } case STRSXP: {
-                    SEXP sexpVec = PROTECT(Rf_allocVector(STRSXP, nRows));
-                    ++numProtects;
+                    cpp11::writable::strings sexpVec(nRows);
 
                     if (i < (nCols - 1)) {
                         for (int j = 0, n1 = nCols - 1, row = i, idx = 0,
                              baseSize = lenGrps.size(); j < baseSize;
                              ++idx, row += n1) {
 
-                            SEXP comb = PROTECT(STRING_ELT(charVec, cartCombs[row]));
+                            auto&& comb = charVec[cartCombs[row]];
 
                             for (int k = 0; k < lenGrps[idx]; ++k, ++j) {
-                                SET_STRING_ELT(sexpVec, j, comb);
+                                sexpVec[j] = comb;
                             }
-
-                            UNPROTECT(1);
                         }
                     } else {
                         for (int j = 0; j < nRows; ++j) {
-                            SET_STRING_ELT(sexpVec, j,
-                                           STRING_ELT(charVec, lastCol[j]));
+                            sexpVec[j] = charVec[lastCol[j]];
                         }
                     }
 
-                    SET_VECTOR_ELT(DataFrame, i, sexpVec);
+                    DataFrame[i] = sexpVec;
                     break;
                 }
             }
         }
 
-        Rf_setAttrib(DataFrame, R_ClassSymbol, Rf_mkString("data.frame"));
-        Rf_setAttrib(DataFrame, R_NamesSymbol,
-                     Rf_getAttrib(RList, R_NamesSymbol));
-        SEXP rownames = PROTECT(Rf_allocVector(INTSXP, nRows));
-        int* intRows  = INTEGER(rownames);
-
-        for (int i = 1; i <= nRows; ++i) {
-            intRows[i - 1] = i;
-        }
-
-        Rf_setAttrib(DataFrame, R_RowNamesSymbol, rownames);
-        UNPROTECT(numProtects + 1);
+        DataFrame.attr("row.names") = {NA_INTEGER, -nRows};
+        DataFrame.names() = RList.names();
+        DataFrame.attr("class") = "data.frame";
         return DataFrame;
     } else {
         if (typeCheck[tInt]) {
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, nRows, nCols));
-            int* intMat = INTEGER(res);
-            GetPureOutput(intMat, res, RList, cartCombs, lastCol,
+            cpp11::writable::integers_matrix<> intMat(nRows, nCols);
+            GetPureOutput(intMat, RList, cartCombs, lastCol,
                           lenGrps, intVec, nCols, nRows);
-            UNPROTECT(1);
-            return res;
+            return intMat;
         } else if (typeCheck[tFac]) {
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, nRows, nCols));
-            int* intMat = INTEGER(res);
-            GetPureOutput(intMat, res, RList, cartCombs, lastCol,
+            cpp11::writable::integers_matrix<> intMat(nRows, nCols);
+            GetPureOutput(intMat, RList, cartCombs, lastCol,
                           lenGrps, intVec, nCols, nRows);
-            SetFactorClass(res, VECTOR_ELT(RList, 0));
-            UNPROTECT(1);
-            return res;
+            // SetFactorClass(res, VECTOR_ELT(RList, 0));
+            return intMat;
         } else if (typeCheck[tLog]) {
-            SEXP res = PROTECT(Rf_allocMatrix(LGLSXP, nRows, nCols));
-            int* intMat = INTEGER(res);
-            GetPureOutput(intMat, res, RList, cartCombs, lastCol,
+            cpp11::writable::logicals_matrix<> boolMat(nRows, nCols);
+            GetPureOutput(boolMat, RList, cartCombs, lastCol,
                           lenGrps, boolVec, nCols, nRows);
-            UNPROTECT(1);
-            return res;
+            return boolMat;
         } else if (typeCheck[tDbl]) {
-            SEXP res = Rf_allocMatrix(REALSXP, nRows, nCols);
-            double* dblMat = REAL(res);
-            GetPureOutput(dblMat, res, RList, cartCombs, lastCol,
+            cpp11::writable::doubles_matrix<> dblMat(nRows, nCols);
+            GetPureOutput(dblMat, RList, cartCombs, lastCol,
                           lenGrps, dblVec, nCols, nRows);
-            return res;
+            return dblMat;
         } else {
-            SEXP res = PROTECT(Rf_allocMatrix(STRSXP, nRows, nCols));
+            cpp11::writable::strings_matrix<> res(nRows, nCols);
             GetCharOutput(res, RList, cartCombs, lastCol,
                           lenGrps, charVec, nCols, nRows);
-            UNPROTECT(1);
             return res;
         }
     }
@@ -402,20 +373,20 @@ void getAtLeastNPrimes(std::vector<int> &primes,
 }
 
 [[cpp11::register]]
-SEXP ComboGridCpp(SEXP RList, SEXP RIsRep) {
+SEXP ComboGridCpp(cpp11::list RList, bool IsRep) {
 
     int sumLength = 0;
     const int nCols = Rf_length(RList);
     std::vector<int> IsFactor(nCols);
 
     for (int i = 0; i < nCols; ++i) {
-        if (Rf_isFactor(VECTOR_ELT(RList, i))) {
+        if (Rf_isFactor(RList[i])) {
             IsFactor[i] = 1;
         } else {
             IsFactor[i] = 0;
         }
 
-        sumLength += Rf_length(VECTOR_ELT(RList, i));
+        sumLength += Rf_length(RList[i]);
     }
 
     std::vector<int> primes;
@@ -423,7 +394,6 @@ SEXP ComboGridCpp(SEXP RList, SEXP RIsRep) {
 
     int numFactorVec = std::accumulate(IsFactor.cbegin(),
                                        IsFactor.cend(), 0);
-    const int IsRep = CleanConvert::convertFlag(RIsRep, "IsRep");
 
     // All duplicates have been removed from RList via
     // lapply(RList, function(x) sort(unique(x)))
@@ -431,14 +401,10 @@ SEXP ComboGridCpp(SEXP RList, SEXP RIsRep) {
     std::unordered_map<std::string, int> mapIndex;
     std::vector<int> typeCheck(5, 0);
 
-    SEXP charVec     = PROTECT(Rf_allocVector(STRSXP, sumLength));
-    SEXP dblSexpVec  = PROTECT(Rf_allocVector(REALSXP, sumLength));
-    SEXP intSexpVec  = PROTECT(Rf_allocVector(INTSXP, sumLength));
-    SEXP boolSexpVec = PROTECT(Rf_allocVector(LGLSXP, sumLength));
-
-    double* dblVec = REAL(dblSexpVec);
-    int* intVec    = INTEGER(intSexpVec);
-    int* boolVec   = INTEGER(boolSexpVec);
+    cpp11::writable::strings charVec(sumLength);
+    std::vector<double> dblVec(sumLength);
+    std::vector<int> intVec(sumLength);
+    std::vector<int> boolVec(sumLength);
 
     std::vector<std::vector<int>> facList(numFactorVec,
                                           std::vector<int>(sumLength, 0));
@@ -446,7 +412,7 @@ SEXP ComboGridCpp(SEXP RList, SEXP RIsRep) {
     for (int i = 0, total = 0, myIndex = 0, facInd = 0; i < nCols; ++i) {
         rcppType myType;
         std::vector<std::string> tempVec;
-        convertToString(tempVec, VECTOR_ELT(RList, i), myType, IsFactor[i]);
+        convertToString(tempVec, RList[i], myType, IsFactor[i]);
         std::size_t j = 0;
 
         for (const auto &v: tempVec) {
@@ -468,23 +434,23 @@ SEXP ComboGridCpp(SEXP RList, SEXP RIsRep) {
 
             switch(myType) {
                 case tInt: {
-                    intVec[myIndex] = INTEGER(VECTOR_ELT(RList, i))[j];
+                    intVec[myIndex] = INTEGER(RList[i])[j];
                     typeCheck[tInt] = 1;
                     break;
                 } case tFac: {
-                    facList[facInd][myIndex] = INTEGER(VECTOR_ELT(RList, i))[j];
+                    facList[facInd][myIndex] = INTEGER(RList[i])[j];
                     typeCheck[tFac] = 1;
                     break;
                 } case tDbl: {
-                    dblVec[myIndex] = REAL(VECTOR_ELT(RList, i))[j];
+                    dblVec[myIndex] = REAL(RList[i])[j];
                     typeCheck[tDbl] = 1;
                     break;
                 } case tStr: {
-                    SET_STRING_ELT(charVec, myIndex, STRING_ELT(VECTOR_ELT(RList, i), j));
+                    charVec[myIndex] = STRING_ELT(RList[i], j);
                     typeCheck[tStr] = 1;
                     break;
                 } case tLog: {
-                    boolVec[myIndex] = INTEGER(VECTOR_ELT(RList, i))[j];
+                    boolVec[myIndex] = INTEGER(RList[i])[j];
                     typeCheck[tLog] = 1;
                     break;
                 }
@@ -504,18 +470,13 @@ SEXP ComboGridCpp(SEXP RList, SEXP RIsRep) {
 
         for (int i = 0; i < nCols; ++i) {
             if (IsFactor[i]) {
-                SEXP facVec = PROTECT(Rf_getAttrib(VECTOR_ELT(RList, i),
-                                                   R_LevelsSymbol));
+                cpp11::strings facVec(Rf_getAttrib(RList[i], R_LevelsSymbol));
                 std::vector<std::string> strVec;
 
-                int len_comp = Rf_length(facVec);
-
-                for (int i = 0; i < len_comp; ++i) {
-                    const std::string temp(CHAR(STRING_ELT(facVec, i)));
+                for (auto f: facVec) {
+                    const std::string temp(CHAR(f));
                     strVec.push_back(temp);
                 }
-
-                UNPROTECT(1);
 
                 if (testLevels.size()) {
                     if (strVec != testLevels) {
@@ -536,9 +497,8 @@ SEXP ComboGridCpp(SEXP RList, SEXP RIsRep) {
     comboGrid(cartCombs, lastCol, lenGrps, myVec, primes, IsRep);
 
     const int nRows = lastCol.size();
-    SEXP res =  PROTECT(GlueComboCart(cartCombs, lastCol, lenGrps, facList,
-                                      typeCheck, IsFactor, RList, intVec,
-                                      boolVec, dblVec, charVec, nRows, nCols, IsDF));
-    UNPROTECT(5);
+    cpp11::sexp res = GlueComboCart(cartCombs, lastCol, lenGrps, facList,
+                                    typeCheck, IsFactor, RList, intVec,
+                                    dblVec, boolVec, charVec, nRows, nCols, IsDF);
     return res;
 }

--- a/src/CartesianContainer.cpp
+++ b/src/CartesianContainer.cpp
@@ -188,9 +188,9 @@ void PoulateColumn(const std::vector<int> &cartCombs,
         for (int j = 0, n1 = nCols - 1, row = i, idx = 0,
              baseSize = lenGrps.size(); idx < baseSize;
              ++idx, row += n1) {
-            
+
             auto&& comb = poolVec[cartCombs[row]];
-            
+
             for (int k = 0; k < lenGrps[idx]; ++k, ++j) {
                 res[j] = comb;
             }

--- a/src/CheckReturn.cpp
+++ b/src/CheckReturn.cpp
@@ -8,11 +8,13 @@ bool CheckConstrnd(SEXP RCnstrntFun, SEXP RCompFun, SEXP Rtarget) {
                   !Rf_isNull(Rtarget);
 
     if (result) {
-        if (!Rf_isString(RCnstrntFun))
+        if (!Rf_isString(RCnstrntFun)) {
             cpp11::stop("constraintFun must be passed as a character");
+        }
 
-        if (!Rf_isString(RCompFun))
+        if (!Rf_isString(RCompFun)) {
             cpp11::stop("comparisonFun must be passed as a character");
+        }
     }
 
     return result;
@@ -102,6 +104,5 @@ SEXP CheckReturn(SEXP Rv, SEXP RCnstrntFun, SEXP RCompFun,
         }
     }
 
-    SEXP sexpRes = Rf_ScalarInteger(res);
-    return sexpRes;
+    return Rf_ScalarInteger(res);
 }

--- a/src/ClassUtils.cpp
+++ b/src/ClassUtils.cpp
@@ -185,23 +185,21 @@ void zUpdateIndex(const std::vector<double> &vNum,
 
     switch (TYPEOF(mat)) {
         case LGLSXP: {
-            SEXP yBool = PROTECT(Rf_allocVector(LGLSXP, m));
+            cpp11::sexp yBool = Rf_allocVector(LGLSXP, m);
             int* matBool = INTEGER(mat);
             int* yBoolPt = INTEGER(yBool);
             UpdateExact(matBool, yBoolPt, vInt, z, lastRow, nRows, m, n1);
-            UNPROTECT(1);
             break;
         } case INTSXP: {
             const int numAdd = static_cast<int>(bAddOne);
-            SEXP yInt = PROTECT(Rf_allocVector(INTSXP, m));
+            cpp11::sexp yInt = Rf_allocVector(INTSXP, m);
             int* matInt = INTEGER(mat);
             int* yIntPt = INTEGER(yInt);
             UpdateExact(matInt, yIntPt, vInt, z,
                         lastRow, nRows, m, n1, numAdd);
-            UNPROTECT(1);
             break;
         } case REALSXP: {
-            SEXP yNum = PROTECT(Rf_allocVector(REALSXP, m));
+            cpp11::sexp yNum = Rf_allocVector(REALSXP, m);
             double* matNum = REAL(mat);
             double* yNumPt = REAL(yNum);
 
@@ -221,10 +219,9 @@ void zUpdateIndex(const std::vector<double> &vNum,
                 z[j] = ind;
             }
 
-            UNPROTECT(1);
             break;
         } case STRSXP: {
-            SEXP yChar = PROTECT(Rf_allocVector(STRSXP, m));
+            cpp11::sexp yChar = Rf_allocVector(STRSXP, m);
 
             for (int i = 0; i < m; ++i) {
                 SET_STRING_ELT(yChar, i,
@@ -242,10 +239,9 @@ void zUpdateIndex(const std::vector<double> &vNum,
                 z[j] = ind;
             }
 
-            UNPROTECT(1);
             break;
         } case CPLXSXP: {
-            SEXP yCmplx = PROTECT(Rf_allocVector(CPLXSXP, m));
+            cpp11::sexp yCmplx = Rf_allocVector(CPLXSXP, m);
             Rcomplex* matCmplx = COMPLEX(mat);
             Rcomplex* xCmplxPt = COMPLEX(v);
             Rcomplex* yCmplxPt = COMPLEX(yCmplx);
@@ -268,10 +264,9 @@ void zUpdateIndex(const std::vector<double> &vNum,
                 z[j] = ind;
             }
 
-            UNPROTECT(1);
             break;
         } case RAWSXP: {
-            SEXP yRaw = PROTECT(Rf_allocVector(RAWSXP, m));
+            cpp11::sexp yRaw = Rf_allocVector(RAWSXP, m);
             Rbyte* matRaw = RAW(mat);
             Rbyte* xRawPt = RAW(v);
             std::vector<Rbyte> stlRawVec(n1 + 1);
@@ -282,7 +277,6 @@ void zUpdateIndex(const std::vector<double> &vNum,
 
             Rbyte* yRawPt = RAW(yRaw);
             UpdateExact(matRaw, yRawPt, stlRawVec, z, lastRow, nRows, m, n1);
-            UNPROTECT(1);
             break;
         } default:{
             cpp11::stop("Only atomic types are supported for v");

--- a/src/CnstrntsSpecialClass.cpp
+++ b/src/CnstrntsSpecialClass.cpp
@@ -29,20 +29,17 @@ void CnstrntsSpecial::startOver() {
 
 SEXP CnstrntsSpecial::nextComb() {
     if (keepGoing) {
-        SEXP res = PROTECT(ComboRes::nextNumCombs(Rf_ScalarInteger(1)));
+        cpp11::sexp res = ComboRes::nextNumCombs(Rf_ScalarInteger(1));
 
         if (Rf_isNull(res)) {
             keepGoing = false;
-            UNPROTECT(1);
             return res;
         } else {
             if (Rf_nrows(res)) {
                 count = dblIndex;
                 Rf_setAttrib(res, R_DimSymbol, R_NilValue);
-                UNPROTECT(1);
                 return res;
             } else {
-                UNPROTECT(1);
                 keepGoing = false;
                 return ToSeeLast();
             }
@@ -56,11 +53,10 @@ SEXP CnstrntsSpecial::nextComb() {
 SEXP CnstrntsSpecial::nextNumCombs(SEXP RNum) {
 
     if (keepGoing) {
-        SEXP res = PROTECT(ComboRes::nextNumCombs(RNum));
+        cpp11::sexp res = ComboRes::nextNumCombs(RNum);
 
         if (Rf_isNull(res)) {
             keepGoing = false;
-            UNPROTECT(1);
             return res;
         } else {
             int num;
@@ -71,10 +67,8 @@ SEXP CnstrntsSpecial::nextNumCombs(SEXP RNum) {
                 const int returned_nrows = Rf_nrows(res);
                 keepGoing = num == returned_nrows;
                 count = dblIndex - (num - returned_nrows);
-                UNPROTECT(1);
                 return res;
             } else {
-                UNPROTECT(1);
                 keepGoing = false;
                 return ToSeeLast();
             }
@@ -88,19 +82,16 @@ SEXP CnstrntsSpecial::nextNumCombs(SEXP RNum) {
 SEXP CnstrntsSpecial::nextGather() {
 
     if (keepGoing) {
-        SEXP res = PROTECT(ComboRes::nextGather());
+        cpp11::sexp res = ComboRes::nextGather();
 
         if (Rf_isNull(res)) {
             keepGoing = false;
-            UNPROTECT(1);
             return res;
         } else if (Rf_nrows(res)) {
             count += Rf_nrows(res);
             keepGoing = false;
-            UNPROTECT(1);
             return res;
         } else {
-            UNPROTECT(1);
             keepGoing = false;
             return ToSeeLast();
         }
@@ -115,7 +106,7 @@ SEXP CnstrntsSpecial::currComb() {
 }
 
 SEXP CnstrntsSpecial::summary() {
-    SEXP res = PROTECT(Combo::summary());
+    cpp11::sexp res = Combo::summary();
     std::string desc(R_CHAR(STRING_ELT(VECTOR_ELT(res, 0), 0)));
 
     std::string val1 = (RTYPE == INTSXP) ?
@@ -144,7 +135,5 @@ SEXP CnstrntsSpecial::summary() {
     SET_VECTOR_ELT(res, 1, Rf_ScalarInteger(count));
     SET_VECTOR_ELT(res, 2, Rf_ScalarReal(R_NaReal));
     SET_VECTOR_ELT(res, 3, Rf_ScalarReal(R_NaReal));
-
-    UNPROTECT(1);
     return res;
 }

--- a/src/CnstrntsToRClass.cpp
+++ b/src/CnstrntsToRClass.cpp
@@ -17,7 +17,7 @@ void SetCurrVec(const std::vector<T> &cnstrntVec,
 template <int sexpType, typename T>
 SEXP CnstrtVecReturn(const std::vector<T> &v) {
 
-    SEXP res = PROTECT(Rf_allocVector(sexpType, v.size()));
+    cpp11::sexp res = Rf_allocVector(sexpType, v.size());
 
     if (sexpType == INTSXP) {
         int* ptrOut = INTEGER(res);
@@ -33,7 +33,6 @@ SEXP CnstrtVecReturn(const std::vector<T> &v) {
         }
     }
 
-    UNPROTECT(1);
     return res;
 }
 
@@ -98,12 +97,11 @@ SEXP CnstrntsToR::GetNextN(int n) {
             const int vecLen = cnstrntVec.size();
             const int numResult = vecLen / m;
 
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, numResult, nCols));
+            cpp11::sexp res = Rf_allocMatrix(INTSXP, numResult, nCols);
             int* matInt = INTEGER(res);
 
             VectorToMatrix(cnstrntVec, resVec, matInt, 0, numResult,
                            width, upperBoundInt, KeepRes, false);
-            UNPROTECT(1);
             return res;
         }
     } else {
@@ -116,12 +114,11 @@ SEXP CnstrntsToR::GetNextN(int n) {
             const int vecLen = cnstrntVec.size();
             const int numResult = vecLen / m;
 
-            SEXP res = PROTECT(Rf_allocMatrix(REALSXP, numResult, nCols));
+            cpp11::sexp res = Rf_allocMatrix(REALSXP, numResult, nCols);
             double* matNum = REAL(res);
 
             VectorToMatrix(cnstrntVec, resVec, matNum, 0, numResult,
                            width, upperBoundDbl, KeepRes, false);
-            UNPROTECT(1);
             return res;
         }
     }
@@ -234,7 +231,7 @@ SEXP CnstrntsToR::currComb() {
 }
 
 SEXP CnstrntsToR::summary() {
-    SEXP res = PROTECT(Combo::summary());
+    cpp11::sexp res = Combo::summary();
     std::string desc(R_CHAR(STRING_ELT(VECTOR_ELT(res, 0), 0)));
 
     constexpr auto max_digits10 = std::numeric_limits<double>::max_digits10;
@@ -295,7 +292,5 @@ SEXP CnstrntsToR::summary() {
     SET_VECTOR_ELT(res, 1, Rf_ScalarInteger(idx));
     SET_VECTOR_ELT(res, 2, Rf_ScalarReal(R_NaReal));
     SET_VECTOR_ELT(res, 3, Rf_ScalarReal(R_NaReal));
-
-    UNPROTECT(1);
     return res;
 }

--- a/src/ComboApplyClass.cpp
+++ b/src/ComboApplyClass.cpp
@@ -2,8 +2,8 @@
 
 SEXP ComboApply::VecApplyReturn() {
 
-    SEXP vectorPass = PROTECT(Rf_allocVector(RTYPE, m));
-    SEXP sexpFun = PROTECT(Rf_lang2(stdFun, R_NilValue));
+    cpp11::sexp vectorPass = Rf_allocVector(RTYPE, m);
+    cpp11::sexp sexpFun = Rf_lang2(stdFun, R_NilValue);
 
     switch (RTYPE) {
         case LGLSXP:
@@ -51,8 +51,7 @@ SEXP ComboApply::VecApplyReturn() {
     }
 
     SETCADR(sexpFun, Rf_duplicate(vectorPass));
-    SEXP res = Rf_eval(sexpFun, rho);
-    UNPROTECT(2);
+    cpp11::sexp res = Rf_eval(sexpFun, rho);
     return res;
 }
 
@@ -144,7 +143,7 @@ SEXP ComboApply::nextNumCombs(SEXP RNum) {
         }
 
         increment(IsGmp, mpzIndex, dblIndex, numIncrement);
-        SEXP res = PROTECT(ApplyForward(nRows));
+        cpp11::sexp res = ApplyForward(nRows);
 
         if (IsGmp) {
             mpz_sub_ui(mpzTemp, mpzIndex, 1u);
@@ -154,7 +153,6 @@ SEXP ComboApply::nextNumCombs(SEXP RNum) {
 
         z = nthResFun(n, m, dblTemp, mpzTemp, myReps);
         if (!IsComb) TopOffPerm(z, myReps, n, m, IsRep, IsMult);
-        UNPROTECT(1);
         return res;
     } else if (CheckEqInd(IsGmp, mpzIndex, dblIndex,
                           computedRowsMpz, computedRows)) {
@@ -233,7 +231,7 @@ SEXP ComboApply::nextGather() {
             dblIndex = computedRows + 1;
         }
 
-        SEXP res = PROTECT(ApplyForward(nRows));
+        cpp11::sexp res = ApplyForward(nRows);
 
         if (IsGmp) {
             mpz_sub_ui(mpzTemp, computedRowsMpz, 1u);
@@ -243,7 +241,6 @@ SEXP ComboApply::nextGather() {
 
         z = nthResFun(n, m, dblTemp, mpzTemp, myReps);
         if (!IsComb) TopOffPerm(z, myReps, n, m, IsRep, IsMult);
-        UNPROTECT(1);
         return res;
     } else {
         return R_NilValue;

--- a/src/ComboClass.cpp
+++ b/src/ComboClass.cpp
@@ -23,7 +23,7 @@ SEXP Combo::ToSeeFirst(bool AdjustIdx) {
 
 SEXP Combo::VecReturn() {
 
-    SEXP res = PROTECT(Rf_allocVector(RTYPE, m));
+    cpp11::sexp res = Rf_allocVector(RTYPE, m);
 
     switch (RTYPE) {
         case LGLSXP:
@@ -75,7 +75,6 @@ SEXP Combo::VecReturn() {
         }
     }
 
-    UNPROTECT(1);
     return res;
 }
 
@@ -88,14 +87,13 @@ SEXP Combo::MatForward(int nRows) {
     SetThreads(LocalPar, maxThreads, nRows,
                myType, nThreads, sexpNThreads, limit);
 
-    SEXP res = PROTECT(GetCombPerms(
+    cpp11::sexp res = GetCombPerms(
         sexpVec, vNum, vInt, n, m, 0, true, IsComb, LocalPar, IsRep, IsMult,
         IsGmp, freqs, z, myReps, dblIndex, mpzIndex, nRows, nThreads, myType
-    ));
+    );
 
     zUpdateIndex(vNum, vInt, z, sexpVec, res, m, nRows);
     if (!IsComb) TopOffPerm(z, myReps, n, m, IsRep, IsMult);
-    UNPROTECT(1);
     return res;
 }
 
@@ -442,7 +440,8 @@ SEXP Combo::summary() {
     const std::string RepStr = (IsRep) ? "with repetition " : "";
     const std::string MultiStr = (IsMult) ? "of a multiset " : "";
     const std::string strDesc = CoPerm + RepStr + MultiStr + "of "
-                                + std::to_string(n) + " choose " + std::to_string(m);
+                                + std::to_string(n) + " choose " +
+                                    std::to_string(m);
     const double dblDiff = (IsGmp) ? 0 : computedRows - dblIndex;
 
     if (IsGmp) {
@@ -452,13 +451,11 @@ SEXP Combo::summary() {
     const char *names[] = {"description", "currentIndex",
                            "totalResults", "totalRemaining", ""};
 
-    SEXP res = PROTECT(Rf_mkNamed(VECSXP, names));
+    cpp11::sexp res = Rf_mkNamed(VECSXP, names);
 
     SET_VECTOR_ELT(res, 0, Rf_mkString(strDesc.c_str()));
     SET_VECTOR_ELT(res, 1, CleanConvert::GetCount(IsGmp, mpzIndex, dblIndex));
     SET_VECTOR_ELT(res, 2, CleanConvert::GetCount(IsGmp, computedRowsMpz, computedRows));
     SET_VECTOR_ELT(res, 3, CleanConvert::GetCount(IsGmp, mpzTemp, dblDiff));
-
-    UNPROTECT(1);
     return res;
 }

--- a/src/ComboGroups.cpp
+++ b/src/ComboGroups.cpp
@@ -17,14 +17,13 @@ void FinalTouch(SEXP res, bool IsArray, int grpSize, int r, int n,
     }
 
     if (IsArray) {
-        SEXP dim = PROTECT(Rf_allocVector(INTSXP, 3));
+        cpp11::sexp dim = Rf_allocVector(INTSXP, 3);
         INTEGER(dim)[0] = nRows;
         INTEGER(dim)[1] = grpSize;
         INTEGER(dim)[2] = r;
         Rf_setAttrib(res, R_DimSymbol, dim);
-        UNPROTECT(1);
 
-        SEXP myNames = PROTECT(Rf_allocVector(STRSXP, r));
+        cpp11::sexp myNames = Rf_allocVector(STRSXP, r);
 
         for (int i = 0; i < r; ++i) {
             SET_STRING_ELT(myNames, i, Rf_mkChar(myColNames[i].c_str()));
@@ -33,13 +32,12 @@ void FinalTouch(SEXP res, bool IsArray, int grpSize, int r, int n,
         if (IsNamed) {
             SetSampleNames(res, IsGmp, nRows, mySample, myBigSamp, myNames, 2);
         } else {
-            SEXP dimNames = PROTECT(Rf_allocVector(VECSXP, 3));
+            cpp11::sexp dimNames = Rf_allocVector(VECSXP, 3);
             SET_VECTOR_ELT(dimNames, 2, myNames);
             Rf_setAttrib(res, R_DimNamesSymbol, dimNames);
-            UNPROTECT(2);
         }
     } else {
-        SEXP myNames = PROTECT(Rf_allocVector(STRSXP, n));
+        cpp11::sexp myNames = Rf_allocVector(STRSXP, n);
 
         for (int i = 0, k = 0; i < r; ++i) {
             for (int j = 0; j < grpSize; ++j, ++k) {
@@ -50,10 +48,9 @@ void FinalTouch(SEXP res, bool IsArray, int grpSize, int r, int n,
         if (IsNamed) {
             SetSampleNames(res, IsGmp, nRows, mySample, myBigSamp, myNames, 1);
         } else {
-            SEXP dimNames = PROTECT(Rf_allocVector(VECSXP, 2));
+            cpp11::sexp dimNames = Rf_allocVector(VECSXP, 2);
             SET_VECTOR_ELT(dimNames, 1, myNames);
             Rf_setAttrib(res, R_DimNamesSymbol, dimNames);
-            UNPROTECT(2);
         }
     }
 
@@ -462,14 +459,13 @@ SEXP ComboGroupsCpp(SEXP Rv, SEXP RNumGroups, SEXP RRetType, SEXP Rlow,
 
     switch (myType) {
         case VecType::Character: {
-            SEXP charVec = PROTECT(Rf_duplicate(Rv));
-            SEXP res = PROTECT(Rf_allocMatrix(STRSXP, numResults, n));
+            cpp11::sexp charVec = Rf_duplicate(Rv);
+            cpp11::sexp res = Rf_allocMatrix(STRSXP, numResults, n);
 
             CharacterGlue(res, charVec, mySample, myVec.get(), startZ,
                           computedRowMpz, computedRows, n, numGroups, grpSize,
                           numResults, IsArray, IsGmp, IsSample, IsNamed);
 
-            UNPROTECT(2);
             return res;
         } case VecType::Complex: {
             std::vector<Rcomplex> stlCmplxVec(n);
@@ -479,7 +475,7 @@ SEXP ComboGroupsCpp(SEXP Rv, SEXP RNumGroups, SEXP RRetType, SEXP Rlow,
                 stlCmplxVec[i] = vecCmplx[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(CPLXSXP, numResults, n));
+            cpp11::sexp res = Rf_allocMatrix(CPLXSXP, numResults, n);
             Rcomplex* matCmplx = COMPLEX(res);
 
             SerialGlue(matCmplx, res, stlCmplxVec, mySample, myVec.get(),
@@ -487,7 +483,6 @@ SEXP ComboGroupsCpp(SEXP Rv, SEXP RNumGroups, SEXP RRetType, SEXP Rlow,
                        grpSize, numResults, IsArray, IsGmp, IsSample,
                        IsNamed);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Raw : {
             std::vector<Rbyte> stlRawVec(n);
@@ -497,14 +492,13 @@ SEXP ComboGroupsCpp(SEXP Rv, SEXP RNumGroups, SEXP RRetType, SEXP Rlow,
                 stlRawVec[i] = vecRaw[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(RAWSXP, numResults, n));
+            cpp11::sexp res = Rf_allocMatrix(RAWSXP, numResults, n);
             Rbyte* matRaw = RAW(res);
 
             SerialGlue(matRaw, res, stlRawVec, mySample, myVec.get(), startZ,
                        computedRowMpz, computedRows, n, numGroups, grpSize,
                        numResults, IsArray, IsGmp, IsSample, IsNamed);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Logical : {
             vInt.assign(n, 0);
@@ -514,17 +508,16 @@ SEXP ComboGroupsCpp(SEXP Rv, SEXP RNumGroups, SEXP RRetType, SEXP Rlow,
                 vInt[i] = vecBool[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(LGLSXP, numResults, n));
+            cpp11::sexp res = Rf_allocMatrix(LGLSXP, numResults, n);
             int* matBool = LOGICAL(res);
 
             SerialGlue(matBool, res, vInt, mySample, myVec.get(), startZ,
                        computedRowMpz, computedRows, n, numGroups, grpSize,
                        numResults, IsArray, IsGmp, IsSample, IsNamed);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Integer : {
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, numResults, n));
+            cpp11::sexp res = Rf_allocMatrix(INTSXP, numResults, n);
             int* matInt = INTEGER(res);
 
             GroupsMain(matInt, res, vInt, startZ, mySample, myVec.get(),
@@ -536,10 +529,9 @@ SEXP ComboGroupsCpp(SEXP Rv, SEXP RNumGroups, SEXP RRetType, SEXP Rlow,
                 SetFactorClass(res, Rv);
             }
 
-            UNPROTECT(1);
             return res;
         } default : {
-            SEXP res = PROTECT(Rf_allocMatrix(REALSXP, numResults, n));
+            cpp11::sexp res = Rf_allocMatrix(REALSXP, numResults, n);
             double* matNum = REAL(res);
 
             GroupsMain(matNum, res, vNum, startZ, mySample, myVec.get(),
@@ -547,7 +539,6 @@ SEXP ComboGroupsCpp(SEXP Rv, SEXP RNumGroups, SEXP RRetType, SEXP Rlow,
                        numGroups, grpSize, numResults, nThreads, IsArray,
                        IsNamed, Parallel, IsGmp, IsSample);
 
-            UNPROTECT(1);
             return res;
         }
     }

--- a/src/ComboResClass.cpp
+++ b/src/ComboResClass.cpp
@@ -7,7 +7,7 @@ SEXP ComboRes::ApplyFun(SEXP mat) {
     }
 
     const int nRows = Rf_nrows(mat);
-    SEXP res = PROTECT(Rf_allocMatrix(RTYPE, nRows, nCols));
+    cpp11::sexp res = Rf_allocMatrix(RTYPE, nRows, nCols);
 
     if (RTYPE == INTSXP) {
         int* ptrOut = INTEGER(res);
@@ -37,13 +37,12 @@ SEXP ComboRes::ApplyFun(SEXP mat) {
         }
     }
 
-    UNPROTECT(1);
     return res;
 }
 
 SEXP ComboRes::VecReturn() {
 
-    SEXP res = PROTECT(Rf_allocVector(RTYPE, nCols));
+    cpp11::sexp res = Rf_allocVector(RTYPE, nCols);
 
     if (ctype == ConstraintType::PartStandard) {
         int* ptrOut = INTEGER(res);
@@ -87,7 +86,6 @@ SEXP ComboRes::VecReturn() {
         }
     }
 
-    UNPROTECT(1);
     return res;
 }
 
@@ -218,16 +216,15 @@ SEXP ComboRes::nextNumCombs(SEXP RNum) {
         }
 
         bUpper   = true;
-        SEXP res = PROTECT(MatrixReturn(nRows));
+        cpp11::sexp res = MatrixReturn(nRows);
         increment(IsGmp, mpzIndex, dblIndex, numIncrement);
 
         // Since this is called with constraints as well, the
         // requested number of results may not materialize thus
         // Rf_nrows(res) may not equal nRows
         nRows = Rf_nrows(res);
-        if (nRows) zUpdateIndex(vNum, vInt, z, sexpVec, res, width, nRows);
+        if (nRows > 0) zUpdateIndex(vNum, vInt, z, sexpVec, res, width, nRows);
         if (!IsComb) TopOffPerm(z, myReps, n, width, IsRep, IsMult);
-        UNPROTECT(1);
         return res;
     } else if (CheckEqInd(IsGmp, mpzIndex, dblIndex,
                           cnstrtCountMpz, cnstrtCount)) {
@@ -238,14 +235,12 @@ SEXP ComboRes::nextNumCombs(SEXP RNum) {
 }
 
 SEXP ComboRes::prevNumCombs(SEXP RNum) {
-    SEXP mat = PROTECT(Combo::prevNumCombs(RNum));
+    cpp11::sexp mat = Combo::prevNumCombs(RNum);
 
     if (Rf_isNull(mat)) {
-        UNPROTECT(1);
         return R_NilValue;
     } else {
-        SEXP res = PROTECT(ApplyFun(mat));
-        UNPROTECT(2);
+        cpp11::sexp res = ApplyFun(mat);
         return res;
     }
 }
@@ -290,8 +285,8 @@ SEXP ComboRes::nextGather() {
             }
         }
 
-        bUpper   = false;
-        SEXP res = PROTECT(MatrixReturn(nRows));
+        bUpper = false;
+        cpp11::sexp res = MatrixReturn(nRows);
 
         if (IsGmp) {
             mpz_add_ui(mpzIndex, cnstrtCountMpz, 1u);
@@ -303,9 +298,8 @@ SEXP ComboRes::nextGather() {
         // requested number of results may not materialize thus
         // Rf_nrows(res) may not equal nRows
         nRows = Rf_nrows(res);
-        if (nRows) zUpdateIndex(vNum, vInt, z, sexpVec, res, width, nRows);
+        if (nRows > 0) zUpdateIndex(vNum, vInt, z, sexpVec, res, width, nRows);
         if (!IsComb) TopOffPerm(z, myReps, n, width, IsRep, IsMult);
-        UNPROTECT(1);
         return res;
     } else {
         return R_NilValue;
@@ -313,14 +307,12 @@ SEXP ComboRes::nextGather() {
 }
 
 SEXP ComboRes::prevGather() {
-    SEXP mat = PROTECT(Combo::prevGather());
+    cpp11::sexp mat = Combo::prevGather();
 
     if (Rf_isNull(mat)) {
-        UNPROTECT(1);
         return R_NilValue;
     } else {
-        SEXP res = PROTECT(ApplyFun(mat));
-        UNPROTECT(2);
+        cpp11::sexp res = ApplyFun(mat);
         return res;
     }
 }
@@ -338,9 +330,8 @@ SEXP ComboRes::currComb() {
 }
 
 SEXP ComboRes::randomAccess(SEXP RindexVec) {
-    SEXP samp = PROTECT(Combo::randomAccess(RindexVec));
-    SEXP res  = PROTECT(Rf_isMatrix(samp) ? ApplyFun(samp) : VecReturn());
-    UNPROTECT(2);
+    cpp11::sexp samp = Combo::randomAccess(RindexVec);
+    cpp11::sexp res  = Rf_isMatrix(samp) ? ApplyFun(samp) : VecReturn();
     return res;
 }
 
@@ -375,10 +366,9 @@ SEXP ComboRes::back() {
 }
 
 SEXP ComboRes::summary() {
-    SEXP res = PROTECT(Combo::summary());
+    cpp11::sexp res = Combo::summary();
     std::string desc(R_CHAR(STRING_ELT(VECTOR_ELT(res, 0), 0)));
     desc += " with " + mainFun + " applied to each result";
     SET_VECTOR_ELT(res, 0, Rf_mkString(desc.c_str()));
-    UNPROTECT(1);
     return res;
 }

--- a/src/ConstraintsMain.cpp
+++ b/src/ConstraintsMain.cpp
@@ -160,17 +160,14 @@ SEXP CombinatoricsCnstrt(SEXP Rv, SEXP Rm, SEXP RisRep, SEXP RFreqs,
     SetThreads(Parallel, maxThreads, nRows,
                myType, nThreads, RnThreads, limit);
 
-    SEXP res = PROTECT(
-        GetConstraints(
-          part, compVec, freqs, myReps, vNum, vInt, tarVals, tarIntVals,
-          startZ, mainFun, funTest, funDbl, lower, lowerMpz[0], userNum,
-          ctype, myType, nThreads, nRows, n, strtLen, cap, m, IsComb,
-          Parallel, IsGmp, IsRep, IsMult, bUpper, KeepRes, numUnknown
-        )
+    cpp11::sexp res = GetConstraints(
+      part, compVec, freqs, myReps, vNum, vInt, tarVals, tarIntVals,
+      startZ, mainFun, funTest, funDbl, lower, lowerMpz[0], userNum,
+      ctype, myType, nThreads, nRows, n, strtLen, cap, m, IsComb,
+      Parallel, IsGmp, IsRep, IsMult, bUpper, KeepRes, numUnknown
     );
 
     mpz_clear(lowerMpz[0]);
     mpz_clear(upperMpz[0]);
-    UNPROTECT(1);
     return res;
 }

--- a/src/DivNumSieve.cpp
+++ b/src/DivNumSieve.cpp
@@ -192,22 +192,20 @@ SEXP GlueInt(int myMin, int myMax, bool bDivSieve,
         DivisorMain(myMin, myMax, bDivSieve, tempNumDivs,
                     MyDivList, myRange, nThreads, maxThreads);
 
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, myRange));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, myRange);
 
         for (std::size_t i = 0; i < myRange; ++i) {
             SET_VECTOR_ELT(myList, i, GetIntVec(MyDivList[i]));
         }
 
         if (keepNames) {
-            ++numUnprotects;
             SetIntNames(myList, myRange, myMin, myMax);
         }
 
-        UNPROTECT(numUnprotects);
         return myList;
     } else {
         std::vector<std::vector<int>> tempList;
-        SEXP facCountV = PROTECT(Rf_allocVector(INTSXP, myRange));
+        cpp11::sexp facCountV = Rf_allocVector(INTSXP, myRange);
         int* ptrFacCount  = INTEGER(facCountV);
         std::fill_n(ptrFacCount, myRange, 2);
 
@@ -215,11 +213,9 @@ SEXP GlueInt(int myMin, int myMax, bool bDivSieve,
                     tempList, myRange, nThreads, maxThreads);
 
         if (keepNames) {
-            ++numUnprotects;
             SetIntNames(facCountV, myRange, myMin, myMax);
         }
 
-        UNPROTECT(numUnprotects);
         return facCountV;
     }
 }
@@ -239,7 +235,7 @@ SEXP GlueDbl(std::int_fast64_t myMin, double myMax,
         DivisorMain(myMin, myMax, bDivSieve, tempNumDivs,
                     MyDivList, myRange, nThreads, maxThreads);
 
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, myRange));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, myRange);
 
         for (std::size_t i = 0; i < myRange; ++i) {
             SET_VECTOR_ELT(myList, i, GetDblVec(MyDivList[i]));
@@ -250,11 +246,10 @@ SEXP GlueDbl(std::int_fast64_t myMin, double myMax,
             SetDblNames(myList, myRange, myMin, myMax);
         }
 
-        UNPROTECT(numUnprotects);
         return myList;
     } else {
         std::vector<std::vector<double>> tempList;
-        SEXP facCountV = PROTECT(Rf_allocVector(INTSXP, myRange));
+        cpp11::sexp facCountV = Rf_allocVector(INTSXP, myRange);
         int* ptrFacCount  = INTEGER(facCountV);
         std::fill_n(ptrFacCount, myRange, 2);
 
@@ -266,7 +261,6 @@ SEXP GlueDbl(std::int_fast64_t myMin, double myMax,
             SetDblNames(facCountV, myRange, myMin, myMax);
         }
 
-        UNPROTECT(numUnprotects);
         return facCountV;
     }
 }
@@ -310,24 +304,22 @@ SEXP DivNumSieveCpp(SEXP Rb1, SEXP Rb2, SEXP RbDivSieve,
 
     if (myMax < 2) {
         if (bDivSieve) {
-            SEXP res = PROTECT(Rf_allocVector(VECSXP, 1));
+            cpp11::sexp res = Rf_allocVector(VECSXP, 1);
             SET_VECTOR_ELT(res, 0, GetIntVec(std::vector<int>(1, 1)));
 
             if (IsNamed) {
                 Rf_setAttrib(res, R_NamesSymbol, Rf_mkString("1"));
             }
 
-            UNPROTECT(1);
             return res;
         } else {
-            SEXP res = PROTECT(Rf_allocVector(INTSXP, 1));
+            cpp11::sexp res = Rf_allocVector(INTSXP, 1);
             INTEGER(res)[0] = 1;
 
             if (IsNamed) {
                 Rf_setAttrib(res, R_NamesSymbol, Rf_mkString("1"));
             }
 
-            UNPROTECT(1);
             return res;
         }
     }

--- a/src/DivNumSieve.cpp
+++ b/src/DivNumSieve.cpp
@@ -182,7 +182,6 @@ void DivisorMain(T myMin, U myMax, bool bDivSieve,
 SEXP GlueInt(int myMin, int myMax, bool bDivSieve,
              bool keepNames, int nThreads, int maxThreads) {
 
-    int numUnprotects = 1;
     std::size_t myRange = (myMax - myMin) + 1;
 
     if (bDivSieve) {
@@ -224,7 +223,6 @@ SEXP GlueDbl(std::int_fast64_t myMin, double myMax,
              bool bDivSieve, bool keepNames,
              int nThreads, int maxThreads) {
 
-    int numUnprotects = 1;
     std::size_t myRange = (myMax - myMin) + 1;
 
     if (bDivSieve) {
@@ -242,7 +240,6 @@ SEXP GlueDbl(std::int_fast64_t myMin, double myMax,
         }
 
         if (keepNames) {
-            ++numUnprotects;
             SetDblNames(myList, myRange, myMin, myMax);
         }
 
@@ -257,7 +254,6 @@ SEXP GlueDbl(std::int_fast64_t myMin, double myMax,
                     tempList, myRange, nThreads, maxThreads);
 
         if (keepNames) {
-            ++numUnprotects;
             SetDblNames(facCountV, myRange, myMin, myMax);
         }
 

--- a/src/ExposeClass.cpp
+++ b/src/ExposeClass.cpp
@@ -57,10 +57,9 @@ SEXP CombClassNew(SEXP RVals, SEXP RboolVec, SEXP freqInfo, SEXP Rparallel,
             Parallel
         );
 
-        SEXP ext = PROTECT(R_MakeExternalPtr(ptr, R_NilValue, R_NilValue));
+        cpp11::sexp ext = R_MakeExternalPtr(ptr, R_NilValue, R_NilValue);
         R_RegisterCFinalizerEx(ext, Finalizer, TRUE);
 
-        UNPROTECT(1);
         return ext;
     } else if (ReturnValue == 2) {
         class ComboApply* ptr = new ComboApply(
@@ -69,10 +68,9 @@ SEXP CombClassNew(SEXP RVals, SEXP RboolVec, SEXP freqInfo, SEXP Rparallel,
             Parallel, RstdFun, Rrho, R_RFunVal
         );
 
-        SEXP ext = PROTECT(R_MakeExternalPtr(ptr, R_NilValue, R_NilValue));
+        cpp11::sexp ext = R_MakeExternalPtr(ptr, R_NilValue, R_NilValue);
         R_RegisterCFinalizerEx(ext, Finalizer, TRUE);
 
-        UNPROTECT(1);
         return ext;
     } else {
         const bool KeepRes = CleanConvert::convertFlag(RKeepRes, "keepResults");
@@ -177,10 +175,9 @@ SEXP CombClassNew(SEXP RVals, SEXP RboolVec, SEXP freqInfo, SEXP Rparallel,
                 computedRows, computedRowsMpz[0]
             );
 
-            SEXP ext = PROTECT(R_MakeExternalPtr(ptr, R_NilValue, R_NilValue));
+            cpp11::sexp ext = R_MakeExternalPtr(ptr, R_NilValue, R_NilValue);
             R_RegisterCFinalizerEx(ext, Finalizer, TRUE);
 
-            UNPROTECT(1);
             return ext;
         } else if (ctype == ConstraintType::General ||
                    ctype == ConstraintType::PartitionEsque) {
@@ -193,10 +190,9 @@ SEXP CombClassNew(SEXP RVals, SEXP RboolVec, SEXP freqInfo, SEXP Rparallel,
                 computedRows, computedRowsMpz[0]
             );
 
-            SEXP ext = PROTECT(R_MakeExternalPtr(ptr, R_NilValue, R_NilValue));
+            cpp11::sexp ext = R_MakeExternalPtr(ptr, R_NilValue, R_NilValue);
             R_RegisterCFinalizerEx(ext, Finalizer, TRUE);
 
-            UNPROTECT(1);
             return ext;
         } else if (ctype == ConstraintType::SpecialCnstrnt) {
             // We must use a single thread to ensure the proper constraint
@@ -214,10 +210,9 @@ SEXP CombClassNew(SEXP RVals, SEXP RboolVec, SEXP freqInfo, SEXP Rparallel,
                 computedRows, computedRowsMpz[0]
             );
 
-            SEXP ext = PROTECT(R_MakeExternalPtr(ptr, R_NilValue, R_NilValue));
+            cpp11::sexp ext = R_MakeExternalPtr(ptr, R_NilValue, R_NilValue);
             R_RegisterCFinalizerEx(ext, Finalizer, TRUE);
 
-            UNPROTECT(1);
             return ext;
         } else {
             class Partitions* ptr = new Partitions(
@@ -228,10 +223,9 @@ SEXP CombClassNew(SEXP RVals, SEXP RboolVec, SEXP freqInfo, SEXP Rparallel,
                 computedRows, computedRowsMpz[0]
             );
 
-            SEXP ext = PROTECT(R_MakeExternalPtr(ptr, R_NilValue, R_NilValue));
+            cpp11::sexp ext = R_MakeExternalPtr(ptr, R_NilValue, R_NilValue);
             R_RegisterCFinalizerEx(ext, Finalizer, TRUE);
 
-            UNPROTECT(1);
             return ext;
         }
     }

--- a/src/FunAssign.cpp
+++ b/src/FunAssign.cpp
@@ -1,5 +1,6 @@
 #include "FunAssign.h"
 #include "cpp11/protect.hpp"
+#include "cpp11/sexp.hpp"
 
 // See function do_vapply found here:
 //     https://github.com/wch/r-source/blob/trunk/src/main/apply.c
@@ -129,12 +130,12 @@ void FunAssign(SEXP res, SEXP vectorPass, SEXP sexpFun,
 
 void SetDims(SEXP RFunVal, SEXP res, int commonLen, int nRows) {
 
-    SEXP dim_v = PROTECT(Rf_getAttrib(RFunVal, R_DimSymbol));
+    cpp11::sexp dim_v = Rf_getAttrib(RFunVal, R_DimSymbol);
     const bool array_value = (TYPEOF(dim_v) == INTSXP && LENGTH(dim_v) >= 1);
 
     if (commonLen != 1) {
         const int rnk_v = array_value ? LENGTH(dim_v) : 1;
-        SEXP dim = PROTECT(Rf_allocVector(INTSXP, rnk_v + 1));
+        cpp11::sexp dim = Rf_allocVector(INTSXP, rnk_v + 1);
         INTEGER(dim)[0] = nRows;
 
         if(array_value) {
@@ -146,9 +147,7 @@ void SetDims(SEXP RFunVal, SEXP res, int commonLen, int nRows) {
         }
 
         Rf_setAttrib(res, R_DimSymbol, dim);
-        UNPROTECT(1);
     }
 
-    UNPROTECT(1);
 }
 

--- a/src/GetClassVals.cpp
+++ b/src/GetClassVals.cpp
@@ -40,7 +40,7 @@ SEXP GetClassVals(SEXP Rv, SEXP Rm, SEXP RisRep, SEXP RFreqs,
     SetValues(myType, myReps, freqs, vInt, vNum, Rv,
               RFreqs, Rm, n, m, IsMult, IsRep, IsConstrained);
 
-    const SEXP sexpVec = PROTECT(CopyRv(Rv, vInt, vNum, myType, IsFactor));
+    const cpp11::sexp sexpVec = CopyRv(Rv, vInt, vNum, myType, IsFactor);
     const double computedRows = GetComputedRows(IsMult, IsComb, IsRep,
                                                 n, m, Rm, freqs, myReps);
     const bool IsGmp = (computedRows > SampleLimit);
@@ -53,12 +53,12 @@ SEXP GetClassVals(SEXP Rv, SEXP Rm, SEXP RisRep, SEXP RFreqs,
                           IsComb, IsRep, n, m, Rm, freqs, myReps);
     }
 
-    SEXP sexpNumRows = PROTECT(CleanConvert::GetCount(
+    cpp11::sexp sexpNumRows = CleanConvert::GetCount(
         IsGmp, computedRowsMpz, computedRows
-    ));
+    );
 
     mpz_clear(computedRowsMpz);
-    SEXP freqsInfo = PROTECT(Rf_allocVector(VECSXP, 2));
+    cpp11::sexp freqsInfo = Rf_allocVector(VECSXP, 2);
     SET_VECTOR_ELT(freqsInfo, 0, GetIntVec(myReps));
     SET_VECTOR_ELT(freqsInfo, 1, GetIntVec(freqs));
 
@@ -66,7 +66,7 @@ SEXP GetClassVals(SEXP Rv, SEXP Rm, SEXP RisRep, SEXP RFreqs,
     const bool IsFullPerm = (IsComb || IsRep) ? false :
         (m == n || m == static_cast<int>(freqs.size()));
 
-    SEXP bVec = PROTECT(Rf_allocVector(LGLSXP, 6));
+    cpp11::sexp bVec = Rf_allocVector(LGLSXP, 6);
     INTEGER(bVec)[0] = IsFactor;
     INTEGER(bVec)[1] = IsComb;
     INTEGER(bVec)[2] = IsMult;
@@ -82,7 +82,7 @@ SEXP GetClassVals(SEXP Rv, SEXP Rm, SEXP RisRep, SEXP RFreqs,
 
     // RVals is a list containing: v, vNum, vInt, m,
     // RcompRows, nThreads, maxThreads
-    SEXP RVals = PROTECT(Rf_allocVector(VECSXP, 7));
+    cpp11::sexp RVals = Rf_allocVector(VECSXP, 7);
     SET_VECTOR_ELT(RVals, 0, sexpVec);
     SET_VECTOR_ELT(RVals, 1, GetDblVec(vNum));
     SET_VECTOR_ELT(RVals, 2, GetIntVec(vInt));
@@ -93,12 +93,11 @@ SEXP GetClassVals(SEXP Rv, SEXP Rm, SEXP RisRep, SEXP RFreqs,
 
     const char *names[] = {"RVals", "bVec", "FreqsInfo",
                            "applyFun", ""};
-    SEXP res = PROTECT(Rf_mkNamed(VECSXP, names));
+    cpp11::sexp res = Rf_mkNamed(VECSXP, names);
     SET_VECTOR_ELT(res, 0, RVals);
     SET_VECTOR_ELT(res, 1, bVec);
     SET_VECTOR_ELT(res, 2, freqsInfo);
     SET_VECTOR_ELT(res, 3, Rf_ScalarLogical(applyFun));
 
-    UNPROTECT(6);
     return res;
 }

--- a/src/GetCombPerm.cpp
+++ b/src/GetCombPerm.cpp
@@ -57,13 +57,12 @@ SEXP GetCombPerms(SEXP Rv, const std::vector<double> &vNum,
 
     switch (myType) {
         case VecType::Character : {
-            SEXP charVec = PROTECT(Rf_duplicate(Rv));
-            SEXP res = PROTECT(Rf_allocMatrix(STRSXP, nRows, m));
+            cpp11::sexp charVec = Rf_duplicate(Rv);
+            cpp11::sexp res = Rf_allocMatrix(STRSXP, nRows, m);
 
             CharacterGlue(res, charVec, IsComb, z, n, m,
                           nRows, freqs, IsMult, IsRep);
 
-            UNPROTECT(2);
             return res;
         } case VecType::Complex : {
             std::vector<Rcomplex> stlCmplxVec(n);
@@ -73,13 +72,12 @@ SEXP GetCombPerms(SEXP Rv, const std::vector<double> &vNum,
                 stlCmplxVec[i] = vecCmplx[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(CPLXSXP, nRows, m));
+            cpp11::sexp res = Rf_allocMatrix(CPLXSXP, nRows, m);
             Rcomplex* matCmplx = COMPLEX(res);
 
             ManagerGlue(matCmplx, stlCmplxVec, z, n, m, nRows, IsComb,
                         phaseOne, generalRet, freqs, IsMult, IsRep);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Raw : {
             std::vector<Rbyte> stlRawVec(n);
@@ -89,13 +87,12 @@ SEXP GetCombPerms(SEXP Rv, const std::vector<double> &vNum,
                 stlRawVec[i] = rawVec[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(RAWSXP, nRows, m));
+            cpp11::sexp res = Rf_allocMatrix(RAWSXP, nRows, m);
             Rbyte* rawMat = RAW(res);
 
             ManagerGlue(rawMat, stlRawVec, z, n, m, nRows, IsComb,
                         phaseOne, generalRet, freqs, IsMult, IsRep);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Logical : {
             std::vector<int> vBool(n, 0);
@@ -105,37 +102,31 @@ SEXP GetCombPerms(SEXP Rv, const std::vector<double> &vNum,
                 vBool[i] = vecBool[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(LGLSXP, nRows, m));
+            cpp11::sexp res = Rf_allocMatrix(LGLSXP, nRows, m);
             int* matBool = LOGICAL(res);
 
             ManagerGlue(matBool, vBool, z, n, m, nRows, IsComb,
                         phaseOne, generalRet, freqs, IsMult, IsRep);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Integer : {
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, nRows, m));
+            cpp11::sexp res = Rf_allocMatrix(INTSXP, nRows, m);
             int* matInt = INTEGER(res);
 
             ParallelGlue(matInt, vInt, n, m, phaseOne, generalRet, IsComb,
                          Parallel, IsRep, IsMult, IsGmp, freqs, z, myReps,
                          lower, lowerMpz, nRows, nThreads);
 
-            if (Rf_isFactor(Rv)) {
-                SetFactorClass(res, Rv);
-            }
-
-            UNPROTECT(1);
+            if (Rf_isFactor(Rv)) SetFactorClass(res, Rv);
             return res;
         } default : {
-            SEXP res = PROTECT(Rf_allocMatrix(REALSXP, nRows, m));
+            cpp11::sexp res = Rf_allocMatrix(REALSXP, nRows, m);
             double* matNum = REAL(res);
 
             ParallelGlue(matNum, vNum, n, m, phaseOne, generalRet, IsComb,
                          Parallel, IsRep, IsMult, IsGmp, freqs, z, myReps,
                          lower, lowerMpz, nRows, nThreads);
 
-            UNPROTECT(1);
             return res;
         }
     }

--- a/src/GetCombPermApply.cpp
+++ b/src/GetCombPermApply.cpp
@@ -12,7 +12,7 @@ void VecApply(SEXP res, const std::vector<T> &v, SEXP vectorPass,
               const std::vector<int> &freqs, std::vector<int> &z, bool IsMult,
               SEXP stdFun, SEXP rho, int commonLen, int commonType) {
 
-    SEXP sexpFun = PROTECT(Rf_lang2(stdFun, R_NilValue));
+    cpp11::sexp sexpFun = Rf_lang2(stdFun, R_NilValue);
 
     if (IsComb) {
         if (IsMult) {
@@ -40,7 +40,6 @@ void VecApply(SEXP res, const std::vector<T> &v, SEXP vectorPass,
         }
     }
 
-    UNPROTECT(1);
 }
 
 void VecApply(SEXP res, SEXP v, SEXP vectorPass,
@@ -48,7 +47,7 @@ void VecApply(SEXP res, SEXP v, SEXP vectorPass,
               const std::vector<int> &freqs, std::vector<int> &z, bool IsMult,
               SEXP stdFun, SEXP rho, int commonLen, int commonType) {
 
-    SEXP sexpFun = PROTECT(Rf_lang2(stdFun, R_NilValue));
+    cpp11::sexp sexpFun = Rf_lang2(stdFun, R_NilValue);
 
     if (IsComb) {
         if (IsMult) {
@@ -76,7 +75,6 @@ void VecApply(SEXP res, SEXP v, SEXP vectorPass,
         }
     }
 
-    UNPROTECT(1);
 }
 
 SEXP ApplyFunction(SEXP v, SEXP vectorPass, int n, int m, bool IsComb,
@@ -90,66 +88,59 @@ SEXP ApplyFunction(SEXP v, SEXP vectorPass, int n, int m, bool IsComb,
 
         switch (TYPEOF(RFunVal)) {
             case STRSXP : {
-                SEXP res = PROTECT(Rf_allocVector(STRSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(STRSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, n, m, IsComb,
                          IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, STRSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } case CPLXSXP : {
-                SEXP res = PROTECT(Rf_allocVector(CPLXSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(CPLXSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, n, m, IsComb,
                          IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, CPLXSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } case RAWSXP : {
-                SEXP res = PROTECT(Rf_allocVector(RAWSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(RAWSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, n, m, IsComb,
                          IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, RAWSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } case LGLSXP : {
-                SEXP res = PROTECT(Rf_allocVector(LGLSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(LGLSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, n, m, IsComb,
                          IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, LGLSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } case INTSXP : {
-                SEXP res = PROTECT(Rf_allocVector(INTSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(INTSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, n, m, IsComb,
                          IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, INTSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } case REALSXP : {
-                SEXP res = PROTECT(Rf_allocVector(REALSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(REALSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, n, m, IsComb,
                          IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, REALSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } default : {
-                SEXP res = PROTECT(Rf_allocVector(VECSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(VECSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, n, m, IsComb,
                          IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, VECSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             }
         }
     } else {
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, nRows));
-        SEXP sexpFun = PROTECT(Rf_lang2(stdFun, R_NilValue));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, nRows);
+        cpp11::sexp sexpFun = Rf_lang2(stdFun, R_NilValue);
 
         if (IsComb) {
             if (IsMult) {
@@ -175,7 +166,6 @@ SEXP ApplyFunction(SEXP v, SEXP vectorPass, int n, int m, bool IsComb,
             }
         }
 
-        UNPROTECT(2);
         return myList;
     }
 }
@@ -193,66 +183,59 @@ SEXP ApplyFunction(const std::vector<T> &v, SEXP vectorPass,
 
         switch (TYPEOF(RFunVal)) {
             case STRSXP : {
-                SEXP res = PROTECT(Rf_allocVector(STRSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(STRSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, ptr_vec, n, m,
                          IsComb, IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, STRSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } case CPLXSXP : {
-                SEXP res = PROTECT(Rf_allocVector(CPLXSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(CPLXSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, ptr_vec, n, m,
                          IsComb, IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, CPLXSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } case RAWSXP : {
-                SEXP res = PROTECT(Rf_allocVector(RAWSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(RAWSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, ptr_vec, n, m,
                          IsComb, IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, RAWSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } case LGLSXP : {
-                SEXP res = PROTECT(Rf_allocVector(LGLSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(LGLSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, ptr_vec, n, m,
                          IsComb, IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, LGLSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } case INTSXP : {
-                SEXP res = PROTECT(Rf_allocVector(INTSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(INTSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, ptr_vec, n, m,
                          IsComb, IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, INTSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } case REALSXP : {
-                SEXP res = PROTECT(Rf_allocVector(REALSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(REALSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, ptr_vec, n, m,
                          IsComb, IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, REALSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             } default : {
-                SEXP res = PROTECT(Rf_allocVector(VECSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(VECSXP, nRows * commonLen);
                 VecApply(res, v, vectorPass, ptr_vec, n, m,
                          IsComb, IsRep, nRows, freqs, z, IsMult,
                          stdFun, rho, commonLen, VECSXP);
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(1);
                 return res;
             }
         }
     } else {
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, nRows));
-        SEXP sexpFun = PROTECT(Rf_lang2(stdFun, R_NilValue));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, nRows);
+        cpp11::sexp sexpFun = Rf_lang2(stdFun, R_NilValue);
 
         if (IsComb) {
             if (IsMult) {
@@ -278,7 +261,6 @@ SEXP ApplyFunction(const std::vector<T> &v, SEXP vectorPass,
             }
         }
 
-        UNPROTECT(2);
         return myList;
     }
 }
@@ -292,65 +274,58 @@ SEXP GetCombPermApply(SEXP Rv, const std::vector<double> &vNum,
 
     switch (myType) {
         case VecType::Character : {
-            SEXP charVec = PROTECT(Rf_duplicate(Rv));
-            SEXP vectorPass = PROTECT(Rf_allocVector(STRSXP, m));
-
-            SEXP res = PROTECT(ApplyFunction(charVec, vectorPass, n, m,
-                                             IsComb, IsRep, nRows, freqs,
-                                             z, IsMult, stdFun, myEnv,
-                                             RFunVal));
-            UNPROTECT(3);
+            cpp11::sexp charVec = Rf_duplicate(Rv);
+            cpp11::sexp vectorPass = Rf_allocVector(STRSXP, m);
+            cpp11::sexp res = ApplyFunction(charVec, vectorPass, n, m,
+                                            IsComb, IsRep, nRows, freqs,
+                                            z, IsMult, stdFun, myEnv,
+                                            RFunVal);
             return res;
         } case VecType::Complex : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(CPLXSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(CPLXSXP, m);
             Rcomplex* ptr_vec = COMPLEX(vectorPass);
 
             Rcomplex* cmplxVec = COMPLEX(Rv);
             std::vector<Rcomplex> vCmplx(cmplxVec, cmplxVec + n);
-            SEXP res = PROTECT(ApplyFunction(vCmplx, vectorPass, ptr_vec,
-                                             n, m, IsComb, IsRep, nRows,
-                                             freqs, z, IsMult, stdFun,
-                                             myEnv, RFunVal));
-            UNPROTECT(2);
+            cpp11::sexp res = ApplyFunction(vCmplx, vectorPass, ptr_vec,
+                                            n, m, IsComb, IsRep, nRows,
+                                            freqs, z, IsMult, stdFun,
+                                            myEnv, RFunVal);
             return res;
         } case VecType::Raw : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(RAWSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(RAWSXP, m);
             Rbyte* ptr_vec = RAW(vectorPass);
 
             Rbyte* rawVec = RAW(Rv);
             std::vector<Rbyte> vByte(rawVec, rawVec + n);
-            SEXP res = PROTECT(ApplyFunction(vByte, vectorPass, ptr_vec,
-                                             n, m, IsComb, IsRep, nRows,
-                                             freqs, z, IsMult, stdFun,
-                                             myEnv, RFunVal));
-            UNPROTECT(2);
+            cpp11::sexp res = ApplyFunction(vByte, vectorPass, ptr_vec,
+                                            n, m, IsComb, IsRep, nRows,
+                                            freqs, z, IsMult, stdFun,
+                                            myEnv, RFunVal);
             return res;
         } case VecType::Logical : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(LGLSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(LGLSXP, m);
             int* ptr_vec = LOGICAL(vectorPass);
-            SEXP res = PROTECT(ApplyFunction(vInt, vectorPass, ptr_vec,
-                                             n, m, IsComb, IsRep, nRows,
-                                             freqs, z, IsMult, stdFun,
-                                             myEnv, RFunVal));
-            UNPROTECT(2);
+            cpp11::sexp res = ApplyFunction(vInt, vectorPass, ptr_vec,
+                                            n, m, IsComb, IsRep, nRows,
+                                            freqs, z, IsMult, stdFun,
+                                            myEnv, RFunVal);
             return res;
         } case VecType::Integer : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(INTSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(INTSXP, m);
             int* ptr_vec = INTEGER(vectorPass);
-            SEXP res = PROTECT(ApplyFunction(vInt, vectorPass, ptr_vec,
-                                             n, m, IsComb, IsRep, nRows,
-                                             freqs, z, IsMult, stdFun,
-                                             myEnv, RFunVal));
-            UNPROTECT(2);
+            cpp11::sexp res = ApplyFunction(vInt, vectorPass, ptr_vec,
+                                            n, m, IsComb, IsRep, nRows,
+                                            freqs, z, IsMult, stdFun,
+                                            myEnv, RFunVal);
             return res;
         } default : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(REALSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(REALSXP, m);
             double* ptr_vec = REAL(vectorPass);
-            SEXP res = PROTECT(ApplyFunction(vNum, vectorPass, ptr_vec,
-                                             n, m, IsComb, IsRep, nRows,
-                                             freqs, z, IsMult, stdFun,
-                                             myEnv, RFunVal));
-            UNPROTECT(2);
+            cpp11::sexp res = ApplyFunction(vNum, vectorPass, ptr_vec,
+                                            n, m, IsComb, IsRep, nRows,
+                                            freqs, z, IsMult, stdFun,
+                                            myEnv, RFunVal);
             return res;
         }
     }

--- a/src/GetConstraints.cpp
+++ b/src/GetConstraints.cpp
@@ -52,12 +52,10 @@ SEXP ConstraintsReturn(
 
     if (part.isPart && !part.solnExist) {
         if (myType == VecType::Integer) {
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, 0, width));
-            UNPROTECT(1);
+            cpp11::sexp res = Rf_allocMatrix(INTSXP, 0, width);
             return res;
         } else {
-            SEXP res = PROTECT(Rf_allocMatrix(REALSXP, 0, width));
-            UNPROTECT(1);
+            cpp11::sexp res = Rf_allocMatrix(REALSXP, 0, width);
             return res;
         }
     } else if (numUnknown || part.ptype == PartitionType::Multiset) {
@@ -77,13 +75,12 @@ SEXP ConstraintsReturn(
             const int vecLen = cnstrntVec.size();
             const int numResult = vecLen / width;
 
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, numResult, nCols));
+            cpp11::sexp res = Rf_allocMatrix(INTSXP, numResult, nCols);
             int* matInt = INTEGER(res);
 
             VectorToMatrix(cnstrntVec, resVec, matInt,
                            part.target, numResult, width,
                            upperBound, xtraCol, part.isPart);
-            UNPROTECT(1);
             return res;
         } else {
             std::vector<double> cnstrntVec;
@@ -101,12 +98,11 @@ SEXP ConstraintsReturn(
             const int vecLen = cnstrntVec.size();
             const int numResult = vecLen / width;
 
-            SEXP res = PROTECT(Rf_allocMatrix(REALSXP, numResult, nCols));
+            cpp11::sexp res = Rf_allocMatrix(REALSXP, numResult, nCols);
             double* matDbl = REAL(res);
             VectorToMatrix(cnstrntVec, resVec, matDbl,
                            part.target, numResult, width,
                            upperBound, xtraCol, part.isPart);
-            UNPROTECT(1);
             return res;
         }
     } else {
@@ -114,7 +110,7 @@ SEXP ConstraintsReturn(
         const int lastCol  = width - 1;
 
         if (myType == VecType::Integer) {
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, nRows, nCols));
+            cpp11::sexp res = Rf_allocMatrix(INTSXP, nRows, nCols);
             int* matInt = INTEGER(res);
 
             if (ctype == ConstraintType::PartStandard) {
@@ -129,10 +125,9 @@ SEXP ConstraintsReturn(
             }
 
             if (xtraCol) AddResultToParts(matInt, part.target, nRows, width);
-            UNPROTECT(1);
             return res;
         } else {
-            SEXP res = PROTECT(Rf_allocMatrix(REALSXP, nRows, nCols));
+            cpp11::sexp res = Rf_allocMatrix(REALSXP, nRows, nCols);
             double* matDbl = REAL(res);
 
             GeneralPartitions(matDbl, vNum, z, part, lower, lowerMpz,
@@ -140,7 +135,6 @@ SEXP ConstraintsReturn(
                               strtLen, cap, IsComb);
 
             if (xtraCol) AddResultToParts(matDbl, part.target, nRows, width);
-            UNPROTECT(1);
             return res;
         }
     }
@@ -171,25 +165,23 @@ SEXP GetConstraints(
 
         if (myType == VecType::Integer) {
             const funcPtr<int> funInt = GetFuncPtr<int>(funTest);
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, nRows, nCols));
+            cpp11::sexp res = Rf_allocMatrix(INTSXP, nRows, nCols);
             int* matInt = INTEGER(res);
 
             ResultsMain(matInt, vInt, funInt, n, m, IsComb, Parallel,
                         IsRep, IsMult, IsGmp, freqs, startZ, myReps,
                         lower, lowerMpz, nRows, nThreads);
 
-            UNPROTECT(1);
             return res;
         } else {
             funDbl = GetFuncPtr<double>(funTest);
-            SEXP res = PROTECT(Rf_allocMatrix(REALSXP, nRows, nCols));
+            cpp11::sexp res = Rf_allocMatrix(REALSXP, nRows, nCols);
             double* matNum = REAL(res);
 
             ResultsMain(matNum, vNum, funDbl, n, m, IsComb, Parallel,
                         IsRep, IsMult, IsGmp, freqs, startZ, myReps,
                         lower, lowerMpz, nRows, nThreads);
 
-            UNPROTECT(1);
             return res;
         }
     } else {

--- a/src/GetPrevCombPerm.cpp
+++ b/src/GetPrevCombPerm.cpp
@@ -57,13 +57,12 @@ SEXP GetPrevCombPerms(SEXP Rv, const std::vector<double> &vNum,
 
     switch (myType) {
         case VecType::Character : {
-            SEXP charVec = PROTECT(Rf_duplicate(Rv));
-            SEXP res = PROTECT(Rf_allocMatrix(STRSXP, nRows, m));
+            cpp11::sexp charVec = Rf_duplicate(Rv);
+            cpp11::sexp res = Rf_allocMatrix(STRSXP, nRows, m);
 
             GetPrevious(res, charVec, z, prevIter, n, m,
                         nRows, freqs, IsComb, IsMult);
 
-            UNPROTECT(2);
             return res;
         } case VecType::Complex : {
             std::vector<Rcomplex> stlCmplxVec(n);
@@ -73,13 +72,12 @@ SEXP GetPrevCombPerms(SEXP Rv, const std::vector<double> &vNum,
                 stlCmplxVec[i] = vecCmplx[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(CPLXSXP, nRows, m));
+            cpp11::sexp res = Rf_allocMatrix(CPLXSXP, nRows, m);
             Rcomplex* matCmplx = COMPLEX(res);
 
             GetPrevious(matCmplx, stlCmplxVec, z, prevIter,
                         n, m, nRows, freqs, IsComb, IsMult);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Raw : {
             std::vector<Rbyte> stlRawVec(n);
@@ -89,13 +87,12 @@ SEXP GetPrevCombPerms(SEXP Rv, const std::vector<double> &vNum,
                 stlRawVec[i] = rawVec[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(RAWSXP, nRows, m));
+            cpp11::sexp res = Rf_allocMatrix(RAWSXP, nRows, m);
             Rbyte* rawMat = RAW(res);
 
             GetPrevious(rawMat, stlRawVec, z, prevIter,
                         n, m, nRows, freqs, IsComb, IsMult);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Logical : {
             std::vector<int> vBool(n, 0);
@@ -105,16 +102,15 @@ SEXP GetPrevCombPerms(SEXP Rv, const std::vector<double> &vNum,
                 vBool[i] = vecBool[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(LGLSXP, nRows, m));
+            cpp11::sexp res = Rf_allocMatrix(LGLSXP, nRows, m);
             int* matBool = LOGICAL(res);
 
             GetPrevious(matBool, vBool, z, prevIter, n,
                         m, nRows, freqs, IsComb, IsMult);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Integer : {
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, nRows, m));
+            cpp11::sexp res = Rf_allocMatrix(INTSXP, nRows, m);
             int* matInt = INTEGER(res);
 
             GetPrevious(matInt, vInt, z, prevIter, n,
@@ -124,16 +120,14 @@ SEXP GetPrevCombPerms(SEXP Rv, const std::vector<double> &vNum,
                 SetFactorClass(res, Rv);
             }
 
-            UNPROTECT(1);
             return res;
         } default : {
-            SEXP res = PROTECT(Rf_allocMatrix(REALSXP, nRows, m));
+            cpp11::sexp res = Rf_allocMatrix(REALSXP, nRows, m);
             double* matNum = REAL(res);
 
             GetPrevious(matNum, vNum, z, prevIter, n,
                         m, nRows, freqs, IsComb, IsMult);
 
-            UNPROTECT(1);
             return res;
         }
     }

--- a/src/GetPrevCombPermApply.cpp
+++ b/src/GetPrevCombPermApply.cpp
@@ -71,7 +71,7 @@ SEXP ApplyFunPrev(SEXP v, SEXP vectorPass, const std::vector<int> &freqs,
                   prevIterPtr prevIter, int n, int m, int nRows,
                   bool IsComb, bool IsMult) {
 
-    SEXP sexpFun = PROTECT(Rf_lang2(stdFun, R_NilValue));
+    cpp11::sexp sexpFun = Rf_lang2(stdFun, R_NilValue);
 
     if (!Rf_isNull(RFunVal)) {
         if (!Rf_isVector(RFunVal)) cpp11::stop("'FUN.VALUE' must be a vector");
@@ -79,82 +79,74 @@ SEXP ApplyFunPrev(SEXP v, SEXP vectorPass, const std::vector<int> &freqs,
 
         switch (TYPEOF(RFunVal)) {
             case STRSXP : {
-                SEXP res = PROTECT(Rf_allocVector(STRSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(STRSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, z, prevIter, n, m,
                              nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, STRSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } case CPLXSXP : {
-                SEXP res = PROTECT(Rf_allocVector(CPLXSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(CPLXSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, z, prevIter, n, m,
                              nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, CPLXSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } case RAWSXP : {
-                SEXP res = PROTECT(Rf_allocVector(RAWSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(RAWSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, z, prevIter, n, m,
                              nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, RAWSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } case LGLSXP : {
-                SEXP res = PROTECT(Rf_allocVector(LGLSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(LGLSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, z, prevIter, n, m,
                              nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, LGLSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } case INTSXP : {
-                SEXP res = PROTECT(Rf_allocVector(INTSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(INTSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, z, prevIter, n, m,
                              nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, INTSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } case REALSXP : {
-                SEXP res = PROTECT(Rf_allocVector(REALSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(REALSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, z, prevIter, n, m,
                              nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, REALSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } default : {
-                SEXP res = PROTECT(Rf_allocVector(VECSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(VECSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, z, prevIter, n, m,
                              nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, VECSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             }
         }
     } else {
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, nRows));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, nRows);
         VecApplyPrev(myList, v, vectorPass, z, prevIter, n, m,
                      nRows, freqs, IsComb, IsMult, sexpFun, rho);
-        UNPROTECT(2);
         return myList;
     }
 }
@@ -165,7 +157,7 @@ SEXP ApplyFunPrev(const std::vector<T> &v, SEXP vectorPass, T* ptr_vec,
                   SEXP stdFun, SEXP rho, SEXP RFunVal, prevIterPtr prevIter,
                   int n, int m, int nRows, bool IsComb, bool IsMult) {
 
-    SEXP sexpFun = PROTECT(Rf_lang2(stdFun, R_NilValue));
+    cpp11::sexp sexpFun = Rf_lang2(stdFun, R_NilValue);
 
     if (!Rf_isNull(RFunVal)) {
         if (!Rf_isVector(RFunVal)) cpp11::stop("'FUN.VALUE' must be a vector");
@@ -173,82 +165,74 @@ SEXP ApplyFunPrev(const std::vector<T> &v, SEXP vectorPass, T* ptr_vec,
 
         switch (TYPEOF(RFunVal)) {
             case STRSXP : {
-                SEXP res = PROTECT(Rf_allocVector(STRSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(STRSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, ptr_vec, z, prevIter,
                              n, m, nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, STRSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } case CPLXSXP : {
-                SEXP res = PROTECT(Rf_allocVector(CPLXSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(CPLXSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, ptr_vec, z, prevIter,
                              n, m, nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, CPLXSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } case RAWSXP : {
-                SEXP res = PROTECT(Rf_allocVector(RAWSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(RAWSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, ptr_vec, z, prevIter,
                              n, m, nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, RAWSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } case LGLSXP : {
-                SEXP res = PROTECT(Rf_allocVector(LGLSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(LGLSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, ptr_vec, z, prevIter,
                              n, m, nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, LGLSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } case INTSXP : {
-                SEXP res = PROTECT(Rf_allocVector(INTSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(INTSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, ptr_vec, z, prevIter,
                              n, m, nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, INTSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } case REALSXP : {
-                SEXP res = PROTECT(Rf_allocVector(REALSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(REALSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, ptr_vec, z, prevIter,
                              n, m, nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, REALSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             } default : {
-                SEXP res = PROTECT(Rf_allocVector(VECSXP, nRows * commonLen));
+                cpp11::sexp res = Rf_allocVector(VECSXP, nRows * commonLen);
 
                 VecApplyPrev(res, v, vectorPass, ptr_vec, z, prevIter,
                              n, m, nRows, freqs, IsComb, IsMult, sexpFun,
                              rho, commonLen, VECSXP);
 
                 SetDims(RFunVal, res, commonLen, nRows);
-                UNPROTECT(2);
                 return res;
             }
         }
     } else {
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, nRows));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, nRows);
         VecApplyPrev(myList, v, vectorPass, ptr_vec, z, prevIter, n,
                      m, nRows, freqs, IsComb, IsMult, sexpFun, rho);
-        UNPROTECT(2);
         return myList;
     }
 }
@@ -263,63 +247,57 @@ SEXP GetPrevCombPermApply(SEXP Rv, const std::vector<double> &vNum,
 
     switch (myType) {
         case VecType::Character : {
-            SEXP charVec = PROTECT(Rf_duplicate(Rv));
-            SEXP vectorPass = PROTECT(Rf_allocVector(STRSXP, m));
-            SEXP res = PROTECT(ApplyFunPrev(charVec, vectorPass, freqs, z,
-                                            stdFun, myEnv, RFunVal, prevIter,
-                                            n, m, nRows, IsComb, IsMult));
-            UNPROTECT(3);
+            cpp11::sexp charVec = Rf_duplicate(Rv);
+            cpp11::sexp vectorPass = Rf_allocVector(STRSXP, m);
+            cpp11::sexp res = ApplyFunPrev(charVec, vectorPass, freqs, z,
+                                           stdFun, myEnv, RFunVal, prevIter,
+                                           n, m, nRows, IsComb, IsMult);
             return res;
         } case VecType::Complex : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(CPLXSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(CPLXSXP, m);
             Rcomplex* ptr_vec = COMPLEX(vectorPass);
 
             Rcomplex* cmplxVec = COMPLEX(Rv);
             std::vector<Rcomplex> vCmplx(cmplxVec, cmplxVec + n);
-            SEXP res = PROTECT(ApplyFunPrev(vCmplx, vectorPass, ptr_vec,
-                                            freqs, z, stdFun, myEnv,
-                                            RFunVal, prevIter, n, m,
-                                            nRows, IsComb, IsMult));
-            UNPROTECT(2);
+            cpp11::sexp res = ApplyFunPrev(vCmplx, vectorPass, ptr_vec,
+                                           freqs, z, stdFun, myEnv,
+                                           RFunVal, prevIter, n, m,
+                                           nRows, IsComb, IsMult);
             return res;
         } case VecType::Raw : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(RAWSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(RAWSXP, m);
             Rbyte* ptr_vec = RAW(vectorPass);
 
             Rbyte* rawVec = RAW(Rv);
             std::vector<Rbyte> vByte(rawVec, rawVec + n);
-            SEXP res = PROTECT(ApplyFunPrev(vByte, vectorPass, ptr_vec,
-                                            freqs, z, stdFun, myEnv,
-                                            RFunVal, prevIter, n, m,
-                                            nRows, IsComb, IsMult));
-            UNPROTECT(2);
+            cpp11::sexp res = ApplyFunPrev(vByte, vectorPass, ptr_vec,
+                                           freqs, z, stdFun, myEnv,
+                                           RFunVal, prevIter, n, m,
+                                           nRows, IsComb, IsMult);
             return res;
         } case VecType::Logical : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(LGLSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(LGLSXP, m);
             int* ptr_vec = LOGICAL(vectorPass);
-            SEXP res = PROTECT(ApplyFunPrev(vInt, vectorPass, ptr_vec,
-                                            freqs, z, stdFun, myEnv,
-                                            RFunVal, prevIter, n, m,
-                                            nRows, IsComb, IsMult));
-            UNPROTECT(2);
+            cpp11::sexp res = ApplyFunPrev(vInt, vectorPass, ptr_vec,
+                                           freqs, z, stdFun, myEnv,
+                                           RFunVal, prevIter, n, m,
+                                           nRows, IsComb, IsMult);
             return res;
         } case VecType::Integer : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(INTSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(INTSXP, m);
             int* ptr_vec = INTEGER(vectorPass);
-            SEXP res = PROTECT(ApplyFunPrev(vInt, vectorPass, ptr_vec,
-                                            freqs, z, stdFun, myEnv,
-                                            RFunVal, prevIter, n, m,
-                                            nRows, IsComb, IsMult));
-            UNPROTECT(2);
+            cpp11::sexp res = ApplyFunPrev(vInt, vectorPass, ptr_vec,
+                                           freqs, z, stdFun, myEnv,
+                                           RFunVal, prevIter, n, m,
+                                           nRows, IsComb, IsMult);
             return res;
         } default : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(REALSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(REALSXP, m);
             double* ptr_vec = REAL(vectorPass);
-            SEXP res = PROTECT(ApplyFunPrev(vNum, vectorPass, ptr_vec,
-                                            freqs, z, stdFun, myEnv,
-                                            RFunVal, prevIter, n, m,
-                                            nRows, IsComb, IsMult));
-            UNPROTECT(2);
+            cpp11::sexp res = ApplyFunPrev(vNum, vectorPass, ptr_vec,
+                                           freqs, z, stdFun, myEnv,
+                                           RFunVal, prevIter, n, m,
+                                           nRows, IsComb, IsMult);
             return res;
         }
     }

--- a/src/MotleyPrimes.cpp
+++ b/src/MotleyPrimes.cpp
@@ -77,7 +77,7 @@ SEXP GlueIntMotley(int myMin, int myMax, bool IsEuler,
 
     if (IsEuler) {
         std::vector<std::vector<int>> tempList;
-        SEXP EulerPhis = PROTECT(Rf_allocVector(INTSXP, myRange));
+        cpp11::sexp EulerPhis = Rf_allocVector(INTSXP, myRange);
         int* ptrEuler  = INTEGER(EulerPhis);
         std::vector<int> numSeq(myRange);
 
@@ -89,7 +89,6 @@ SEXP GlueIntMotley(int myMin, int myMax, bool IsEuler,
             SetIntNames(EulerPhis, myRange, myMin, myMax);
         }
 
-        UNPROTECT(numUnprotects);
         return EulerPhis;
     } else {
         std::vector<std::vector<int>>
@@ -100,7 +99,7 @@ SEXP GlueIntMotley(int myMin, int myMax, bool IsEuler,
         MotleyMain(myMin, myMax, IsEuler, tempEuler,
                    tempVec, primeList, nThreads, maxThreads);
 
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, myRange));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, myRange);
 
         for (std::size_t i = 0; i < myRange; ++i) {
             SET_VECTOR_ELT(myList, i, GetIntVec(primeList[i]));
@@ -111,7 +110,6 @@ SEXP GlueIntMotley(int myMin, int myMax, bool IsEuler,
             SetIntNames(myList, myRange, myMin, myMax);
         }
 
-        UNPROTECT(numUnprotects);
         return myList;
     }
 }
@@ -124,7 +122,7 @@ SEXP GlueDblMotley(std::int64_t myMin, double myMax, bool IsEuler,
 
     if (IsEuler) {
         std::vector<std::vector<std::int64_t>> tempList;
-        SEXP EulerPhis = PROTECT(Rf_allocVector(REALSXP, myRange));
+        cpp11::sexp EulerPhis = Rf_allocVector(REALSXP, myRange);
         double* ptrEuler = REAL(EulerPhis);
         std::vector<std::int64_t> numSeq(myRange);
 
@@ -137,7 +135,6 @@ SEXP GlueDblMotley(std::int64_t myMin, double myMax, bool IsEuler,
                         static_cast<double>(myMin), myMax);
         }
 
-        UNPROTECT(numUnprotects);
         return EulerPhis;
     } else {
         std::vector<std::vector<std::int64_t>>
@@ -148,7 +145,7 @@ SEXP GlueDblMotley(std::int64_t myMin, double myMax, bool IsEuler,
         MotleyMain(myMin, myMax, IsEuler, tempEuler,
                    tempVec, primeList, nThreads, maxThreads);
 
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, myRange));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, myRange);
 
         for (std::size_t i = 0; i < myRange; ++i) {
             SET_VECTOR_ELT(myList, i, GetInt64Vec(primeList[i]));
@@ -160,7 +157,6 @@ SEXP GlueDblMotley(std::int64_t myMin, double myMax, bool IsEuler,
                         static_cast<double>(myMin), myMax);
         }
 
-        UNPROTECT(numUnprotects);
         return myList;
     }
 }
@@ -201,24 +197,22 @@ SEXP MotleyContainer(SEXP Rb1, SEXP Rb2, SEXP RIsEuler, SEXP RNamed,
 
     if (myMax < 2) {
         if (IsEuler) {
-            SEXP res = PROTECT(Rf_allocVector(INTSXP, 1));
+            cpp11::sexp res = Rf_allocVector(INTSXP, 1);
             INTEGER(res)[0] = 1;
 
             if (IsNamed) {
                 Rf_setAttrib(res, R_NamesSymbol, Rf_mkString("1"));
             }
 
-            UNPROTECT(1);
             return res;
         } else {
-            SEXP res = PROTECT(Rf_allocVector(VECSXP, 1));
+            cpp11::sexp res = Rf_allocVector(VECSXP, 1);
             SET_VECTOR_ELT(res, 0, Rf_allocVector(INTSXP, 0));
 
             if (IsNamed) {
                 Rf_setAttrib(res, R_NamesSymbol, Rf_mkString("1"));
             }
 
-            UNPROTECT(1);
             return res;
         }
     }

--- a/src/PartitionsClass.cpp
+++ b/src/PartitionsClass.cpp
@@ -27,7 +27,7 @@ void Partitions::MoveZToIndex() {
 
 SEXP Partitions::MultisetMatrix(int nRows) {
 
-    SEXP res = PROTECT(Rf_allocMatrix(RTYPE, nRows, nCols));
+    cpp11::sexp res = Rf_allocMatrix(RTYPE, nRows, nCols);
     const int lastRow = nRows - 1;
 
     if (RTYPE == INTSXP) {
@@ -62,7 +62,6 @@ SEXP Partitions::MultisetMatrix(int nRows) {
         }
     }
 
-    UNPROTECT(1);
     return res;
 }
 
@@ -157,12 +156,11 @@ SEXP Partitions::nextNumCombs(SEXP RNum) {
             increment(IsGmp, mpzIndex, dblIndex, numIncrement);
             return MultisetMatrix(nRows);
         } else {
-            bUpper   = true;
-            SEXP res = PROTECT(MatrixReturn(nRows));
+            bUpper = true;
+            cpp11::sexp res = MatrixReturn(nRows);
             increment(IsGmp, mpzIndex, dblIndex, numIncrement);
             zUpdateIndex(vNum, vInt, z, sexpVec, res, width, nRows, bAddOne);
             SetPartValues();
-            UNPROTECT(1);
             return res;
         }
     } else if (CheckEqInd(IsGmp, mpzIndex, dblIndex,
@@ -213,11 +211,10 @@ SEXP Partitions::nextGather() {
         if (part.ptype == PartitionType::Multiset) {
             return MultisetMatrix(nRows);
         } else {
-            bUpper   = false;
-            SEXP res = PROTECT(MatrixReturn(nRows));
+            bUpper = false;
+            cpp11::sexp res = MatrixReturn(nRows);
             zUpdateIndex(vNum, vInt, z, sexpVec, res, width, nRows, bAddOne);
             SetPartValues();
-            UNPROTECT(1);
             return res;
         }
     } else {
@@ -268,28 +265,28 @@ SEXP Partitions::randomAccess(SEXP RindexVec) {
                    myType, nThreads, sexpNThreads, limit);
 
         if (myType == VecType::Integer) {
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, sampSize, part.width));
+            cpp11::sexp res = Rf_allocMatrix(INTSXP, sampSize, part.width);
             int* matInt = INTEGER(res);
 
             ThreadSafeSample(matInt, res, vInt, mySample, mpzVec.get(),
                              myReps, nthParts, part.width, sampSize,
                              nThreads, Parallel, false, part.mapTar,
                              strtLen, cap, IsGmp);
+
             zUpdateIndex(vNum, vInt, z, sexpVec, res, width, sampSize, bAddOne);
             SetPartValues();
-            UNPROTECT(1);
             return res;
         } else {
-            SEXP res = PROTECT(Rf_allocMatrix(REALSXP, sampSize, part.width));
+            cpp11::sexp res = Rf_allocMatrix(REALSXP, sampSize, part.width);
             double* matNum = REAL(res);
 
             ThreadSafeSample(matNum, res, vNum, mySample, mpzVec.get(),
                              myReps, nthParts, part.width, sampSize,
                              nThreads, Parallel, false, part.mapTar,
                              strtLen, cap, IsGmp);
+
             zUpdateIndex(vNum, vInt, z, sexpVec, res, width, sampSize, bAddOne);
             SetPartValues();
-            UNPROTECT(1);
             return res;
         }
     } else {
@@ -357,13 +354,11 @@ SEXP Partitions::summary() {
     const char *names[] = {"description", "currentIndex",
                            "totalResults", "totalRemaining", ""};
 
-    SEXP res = PROTECT(Rf_mkNamed(VECSXP, names));
+    cpp11::sexp res = Rf_mkNamed(VECSXP, names);
 
     SET_VECTOR_ELT(res, 0, Rf_mkString(strDesc.c_str()));
     SET_VECTOR_ELT(res, 1, CleanConvert::GetCount(IsGmp, mpzIndex, dblIndex));
     SET_VECTOR_ELT(res, 2, CleanConvert::GetCount(IsGmp, cnstrtCountMpz, cnstrtCount));
     SET_VECTOR_ELT(res, 3, CleanConvert::GetCount(IsGmp, mpzTemp, dblDiff));
-
-    UNPROTECT(1);
     return res;
 }

--- a/src/PartitionsDesign.cpp
+++ b/src/PartitionsDesign.cpp
@@ -122,8 +122,8 @@ SEXP GetDesign(const PartDesign &part, ConstraintType ctype,
                                          part.width * part.shift) /
                                          part.slope;
 
-    SEXP sexp_vec = PROTECT(Rf_allocVector(INTSXP, lenV));
-    SEXP sexp_index = PROTECT(Rf_allocVector(INTSXP, part.startZ.size()));
+    cpp11::sexp sexp_vec = Rf_allocVector(INTSXP, lenV);
+    cpp11::sexp sexp_index = Rf_allocVector(INTSXP, part.startZ.size());
 
     for (int i = 0; i < lenV; ++i) {
         INTEGER(sexp_vec)[i] = vMap[i];
@@ -144,7 +144,7 @@ SEXP GetDesign(const PartDesign &part, ConstraintType ctype,
                            "mapped_target", "first_index_vector",
                            "eqn_check", "partition_type", ""};
 
-    SEXP res = PROTECT(Rf_mkNamed(VECSXP, names));
+    cpp11::sexp res = Rf_mkNamed(VECSXP, names);
     SET_VECTOR_ELT(res, 0, CleanConvert::GetCount(part.isGmp, part.bigCount, part.count));
     SET_VECTOR_ELT(res, 1, sexp_vec);
     SET_VECTOR_ELT(res, 2, Rf_ScalarInteger(part.mapTar));
@@ -152,6 +152,5 @@ SEXP GetDesign(const PartDesign &part, ConstraintType ctype,
     SET_VECTOR_ELT(res, 4, Rf_ScalarLogical(eqn_check_val));
     SET_VECTOR_ELT(res, 5, Rf_mkString(ptype.c_str()));
 
-    UNPROTECT(3);
     return res;
 }

--- a/src/PollardRho.cpp
+++ b/src/PollardRho.cpp
@@ -92,7 +92,7 @@ SEXP PolGlueInt(std::vector<double> &myNums, int myMax,
             PollardRhoMaster(myNums, myMax, bPrimeFacs, bAllFacs,
                              MyPrimeList, tempVec, myRange, nThreads, maxThreads);
 
-            SEXP myList = PROTECT(Rf_allocVector(VECSXP, myRange));
+            cpp11::sexp myList = Rf_allocVector(VECSXP, myRange);
 
             for (std::size_t i = 0; i < myRange; ++i) {
                 SET_VECTOR_ELT(myList, i, GetIntVec(MyPrimeList[i]));
@@ -103,7 +103,6 @@ SEXP PolGlueInt(std::vector<double> &myNums, int myMax,
                 SetDblNames(myList, myNums);
             }
 
-            UNPROTECT(numUnprotects);
             return myList;
         }
     } else if (bAllFacs) {
@@ -153,7 +152,7 @@ SEXP PolGlueInt(std::vector<double> &myNums, int myMax,
         PollardRhoMaster(myNums, myMax, bPrimeFacs, bAllFacs,
                          MyPrimeList, tempVec, myRange, nThreads, maxThreads);
 
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, myRange));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, myRange);
 
         for (std::size_t i = 0; i < myRange; ++i) {
             SET_VECTOR_ELT(myList, i, GetIntVec(MyPrimeList[i]));
@@ -164,10 +163,9 @@ SEXP PolGlueInt(std::vector<double> &myNums, int myMax,
             SetDblNames(myList, myNums);
         }
 
-        UNPROTECT(numUnprotects);
         return myList;
     } else {
-        SEXP isPrimeVec = PROTECT(Rf_allocVector(LGLSXP, myRange));
+        cpp11::sexp isPrimeVec = Rf_allocVector(LGLSXP, myRange);
         int* ptrPrimeVec = INTEGER(isPrimeVec);
         std::fill_n(ptrPrimeVec, myRange, 1);
         std::vector<std::vector<int>> tempList;
@@ -180,7 +178,6 @@ SEXP PolGlueInt(std::vector<double> &myNums, int myMax,
             SetDblNames(isPrimeVec, myNums);
         }
 
-        UNPROTECT(numUnprotects);
         return isPrimeVec;
     }
 }
@@ -214,7 +211,7 @@ SEXP PolGlueDbl(std::vector<double> &myNums, double myMax,
                              false, MyPrimeList, tempVec,
                              myRange, nThreads, maxThreads);
 
-            SEXP myList = PROTECT(Rf_allocVector(VECSXP, myRange));
+            cpp11::sexp myList = Rf_allocVector(VECSXP, myRange);
 
             for (std::size_t i = 0; i < myRange; ++i) {
                 SET_VECTOR_ELT(myList, i, GetDblVec(MyPrimeList[i]));
@@ -225,7 +222,6 @@ SEXP PolGlueDbl(std::vector<double> &myNums, double myMax,
                 SetDblNames(myList, myNums);
             }
 
-            UNPROTECT(numUnprotects);
             return myList;
         }
     } else if (bAllFacs) {
@@ -276,7 +272,7 @@ SEXP PolGlueDbl(std::vector<double> &myNums, double myMax,
                          true, MyPrimeList, tempVec,
                          myRange, nThreads, maxThreads);
 
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, myRange));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, myRange);
 
         for (std::size_t i = 0; i < myRange; ++i) {
             SET_VECTOR_ELT(myList, i, GetDblVec(MyPrimeList[i]));
@@ -287,10 +283,9 @@ SEXP PolGlueDbl(std::vector<double> &myNums, double myMax,
             SetDblNames(myList, myNums);
         }
 
-        UNPROTECT(numUnprotects);
         return myList;
     } else {
-        SEXP isPrimeVec = PROTECT(Rf_allocVector(LGLSXP, myRange));
+        cpp11::sexp isPrimeVec = Rf_allocVector(LGLSXP, myRange);
         int* ptrPrimeVec = INTEGER(isPrimeVec);
         std::fill_n(ptrPrimeVec, myRange, 1);
         std::vector<std::vector<double>> tempList;
@@ -303,7 +298,6 @@ SEXP PolGlueDbl(std::vector<double> &myNums, double myMax,
             SetDblNames(isPrimeVec, myNums);
         }
 
-        UNPROTECT(numUnprotects);
         return isPrimeVec;
     }
 }

--- a/src/PrimeSieve.cpp
+++ b/src/PrimeSieve.cpp
@@ -81,7 +81,7 @@ SEXP PrimeSieveCpp(SEXP Rb1, SEXP Rb2, SEXP RNumThreads,
                 runningCount.push_back(numPrimes);
             }
 
-            SEXP res = PROTECT(Rf_allocVector(REALSXP, numPrimes));
+            cpp11::sexp res = Rf_allocVector(REALSXP, numPrimes);
             double* primes = REAL(res);
 
             for (int i = 0; i < numSects; ++i) {
@@ -89,12 +89,10 @@ SEXP PrimeSieveCpp(SEXP Rb1, SEXP Rb2, SEXP RNumThreads,
                           primes + runningCount[i]);
             }
 
-            UNPROTECT(1);
             return res;
         } else {
-            SEXP primes = PROTECT(Rf_allocVector(REALSXP, tempPrimes.size()));
+            cpp11::sexp primes = Rf_allocVector(REALSXP, tempPrimes.size());
             std::copy(tempPrimes.cbegin(), tempPrimes.cend(), REAL(primes));
-            UNPROTECT(1);
             return primes;
         }
     } else {
@@ -111,7 +109,7 @@ SEXP PrimeSieveCpp(SEXP Rb1, SEXP Rb2, SEXP RNumThreads,
                 runningCount.push_back(numPrimes);
             }
 
-            SEXP res = PROTECT(Rf_allocVector(INTSXP, numPrimes));
+            cpp11::sexp res = Rf_allocVector(INTSXP, numPrimes);
             int* primes = INTEGER(res);
 
             for (int i = 0; i < numSects; ++i) {
@@ -119,12 +117,10 @@ SEXP PrimeSieveCpp(SEXP Rb1, SEXP Rb2, SEXP RNumThreads,
                           primes + runningCount[i]);
             }
 
-            UNPROTECT(1);
             return res;
         } else {
-            SEXP primes = PROTECT(Rf_allocVector(INTSXP, tempPrimes.size()));
+            cpp11::sexp primes = Rf_allocVector(INTSXP, tempPrimes.size());
             std::move(tempPrimes.cbegin(), tempPrimes.cend(), INTEGER(primes));
-            UNPROTECT(1);
             return primes;
         }
     }

--- a/src/SampCombPermStd.cpp
+++ b/src/SampCombPermStd.cpp
@@ -198,13 +198,12 @@ SEXP SampCombPermMain(SEXP Rv, const std::vector<int> &vInt,
 
     switch (myType) {
         case VecType::Character : {
-            SEXP charVec = PROTECT(Rf_duplicate(Rv));
-            SEXP res = PROTECT(Rf_allocMatrix(STRSXP, sampSize, m));
+            cpp11::sexp charVec = Rf_duplicate(Rv);
+            cpp11::sexp res = Rf_allocMatrix(STRSXP, sampSize, m);
 
             SampleResults(res, charVec, mySample, myBigSamp, myReps,
                           nthResFun, m, sampSize, n, IsGmp, IsNamed);
 
-            UNPROTECT(2);
             return res;
         } case VecType::Complex : {
             std::vector<Rcomplex> stlCmplxVec(n);
@@ -214,14 +213,13 @@ SEXP SampCombPermMain(SEXP Rv, const std::vector<int> &vInt,
                 stlCmplxVec[i] = vecCmplx[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(CPLXSXP, sampSize, m));
+            cpp11::sexp res = Rf_allocMatrix(CPLXSXP, sampSize, m);
             Rcomplex* matCmplx = COMPLEX(res);
 
             SampNoThrdSafe(matCmplx, res, stlCmplxVec, mySample,
                            myBigSamp, myReps, nthResFun, m, sampSize,
                            n, IsGmp, IsNamed);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Raw : {
             std::vector<Rbyte> stlRawVec(n);
@@ -231,14 +229,13 @@ SEXP SampCombPermMain(SEXP Rv, const std::vector<int> &vInt,
                 stlRawVec[i] = rawVec[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(RAWSXP, sampSize, m));
+            cpp11::sexp res = Rf_allocMatrix(RAWSXP, sampSize, m);
             Rbyte* rawMat = RAW(res);
 
             SampNoThrdSafe(rawMat, res, stlRawVec, mySample,
                            myBigSamp, myReps, nthResFun, m, sampSize,
                            n, IsGmp, IsNamed);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Logical : {
             std::vector<int> vBool(n, 0);
@@ -248,16 +245,15 @@ SEXP SampCombPermMain(SEXP Rv, const std::vector<int> &vInt,
                 vBool[i] = vecBool[i];
             }
 
-            SEXP res = PROTECT(Rf_allocMatrix(LGLSXP, sampSize, m));
+            cpp11::sexp res = Rf_allocMatrix(LGLSXP, sampSize, m);
             int* matBool = LOGICAL(res);
 
             SampNoThrdSafe(matBool, res, vBool, mySample, myBigSamp, myReps,
                            nthResFun, m, sampSize, n, IsGmp, IsNamed);
 
-            UNPROTECT(1);
             return res;
         } case VecType::Integer : {
-            SEXP res = PROTECT(Rf_allocMatrix(INTSXP, sampSize, m));
+            cpp11::sexp res = Rf_allocMatrix(INTSXP, sampSize, m);
             int* matInt = INTEGER(res);
 
             ThreadSafeSample(matInt, res, vInt, mySample, myBigSamp,
@@ -268,17 +264,15 @@ SEXP SampCombPermMain(SEXP Rv, const std::vector<int> &vInt,
                 SetFactorClass(res, Rv);
             }
 
-            UNPROTECT(1);
             return res;
         } default : {
-            SEXP res = PROTECT(Rf_allocMatrix(REALSXP, sampSize, m));
+            cpp11::sexp res = Rf_allocMatrix(REALSXP, sampSize, m);
             double* matNum = REAL(res);
 
             ThreadSafeSample(matNum, res, vNum, mySample, myBigSamp,
                              myReps, nthResFun, m, sampSize, nThreads,
                              Parallel, IsNamed, IsGmp, n);
 
-            UNPROTECT(1);
             return res;
         }
     }

--- a/src/SampleApply.cpp
+++ b/src/SampleApply.cpp
@@ -11,7 +11,7 @@ void SampleApplyFun(SEXP res, const std::vector<T> &v, SEXP vectorPass,
                     int commonLen = 1, int commonType = INTSXP) {
 
     const int retType = TYPEOF(res);
-    SEXP sexpFun = PROTECT(Rf_lang2(func, R_NilValue));
+    cpp11::sexp sexpFun = Rf_lang2(func, R_NilValue);
 
     if (IsGmp) {
         for (int count = 0; count < sampSize; ++count) {
@@ -44,7 +44,6 @@ void SampleApplyFun(SEXP res, const std::vector<T> &v, SEXP vectorPass,
         mpz_clear(mpzDefault);
     }
 
-    UNPROTECT(1);
 
     if (IsNamed) {
         SetSampleNames(res, IsGmp, sampSize, mySample, myBigSamp);
@@ -59,7 +58,7 @@ void SampleApplyFun(SEXP res, SEXP v, SEXP vectorPass,
                     int commonLen = 1, int commonType = INTSXP) {
 
     const int retType = TYPEOF(res);
-    SEXP sexpFun = PROTECT(Rf_lang2(func, R_NilValue));
+    cpp11::sexp sexpFun = Rf_lang2(func, R_NilValue);
 
     if (IsGmp) {
         for (int count = 0; count < sampSize; ++count) {
@@ -92,7 +91,6 @@ void SampleApplyFun(SEXP res, SEXP v, SEXP vectorPass,
         mpz_clear(mpzDefault);
     }
 
-    UNPROTECT(1);
 
     if (IsNamed) {
         SetSampleNames(res, IsGmp, sampSize, mySample, myBigSamp);
@@ -104,7 +102,7 @@ SEXP ApplyFunction(const std::vector<T> &v, SEXP vectorPass,
                    T* ptr_vec, const std::vector<double> &mySample,
                    mpz_t *const myBigSamp, const std::vector<int> &myReps,
                    SEXP stdFun, SEXP rho, SEXP RFunVal,
-                   nthResultPtr nthResFun, int m, int sampSize,
+                   nthResultPtr nthResFun, int m, int n_samp,
                    bool IsNamed, bool IsGmp, int lenV) {
 
     if (!Rf_isNull(RFunVal)) {
@@ -113,104 +111,82 @@ SEXP ApplyFunction(const std::vector<T> &v, SEXP vectorPass,
 
         switch (TYPEOF(RFunVal)) {
             case STRSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(STRSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(STRSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, ptr_vec, mySample,
                                myBigSamp, myReps, stdFun, rho, nthResFun,
-                               m, sampSize, IsNamed, IsGmp, lenV,
+                               m, n_samp, IsNamed, IsGmp, lenV,
                                commonLen, STRSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } case CPLXSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(CPLXSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(CPLXSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, ptr_vec, mySample,
                                myBigSamp, myReps, stdFun, rho, nthResFun,
-                               m, sampSize, IsNamed, IsGmp, lenV,
+                               m, n_samp, IsNamed, IsGmp, lenV,
                                commonLen, CPLXSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } case RAWSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(RAWSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(RAWSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, ptr_vec, mySample,
                                myBigSamp, myReps, stdFun, rho, nthResFun,
-                               m, sampSize, IsNamed, IsGmp, lenV,
+                               m, n_samp, IsNamed, IsGmp, lenV,
                                commonLen, RAWSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } case LGLSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(LGLSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(LGLSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, ptr_vec, mySample,
                                myBigSamp, myReps, stdFun, rho, nthResFun,
-                               m, sampSize, IsNamed, IsGmp, lenV,
+                               m, n_samp, IsNamed, IsGmp, lenV,
                                commonLen, LGLSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } case INTSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(INTSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(INTSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, ptr_vec, mySample,
                                myBigSamp, myReps, stdFun, rho, nthResFun,
-                               m, sampSize, IsNamed, IsGmp, lenV,
+                               m, n_samp, IsNamed, IsGmp, lenV,
                                commonLen, INTSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } case REALSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(REALSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(REALSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, ptr_vec, mySample,
                                myBigSamp, myReps, stdFun, rho, nthResFun,
-                               m, sampSize, IsNamed, IsGmp, lenV,
+                               m, n_samp, IsNamed, IsGmp, lenV,
                                commonLen, REALSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } default : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(VECSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(VECSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, ptr_vec, mySample,
                                myBigSamp, myReps, stdFun, rho, nthResFun,
-                               m, sampSize, IsNamed, IsGmp, lenV,
+                               m, n_samp, IsNamed, IsGmp, lenV,
                                commonLen, VECSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             }
         }
     } else {
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, sampSize));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, n_samp);
         SampleApplyFun(myList, v, vectorPass, ptr_vec, mySample,
                        myBigSamp, myReps, stdFun, rho, nthResFun,
-                       m, sampSize, IsNamed, IsGmp, lenV);
-        UNPROTECT(1);
+                       m, n_samp, IsNamed, IsGmp, lenV);
         return myList;
     }
 }
@@ -219,7 +195,7 @@ SEXP ApplyFunction(SEXP v, SEXP vectorPass,
                    const std::vector<double> &mySample,
                    mpz_t *const myBigSamp, const std::vector<int> &myReps,
                    SEXP stdFun, SEXP rho, SEXP RFunVal,
-                   nthResultPtr nthResFun, int m, int sampSize,
+                   nthResultPtr nthResFun, int m, int n_samp,
                    bool IsNamed, bool IsGmp, int lenV) {
 
     if (!Rf_isNull(RFunVal)) {
@@ -228,97 +204,75 @@ SEXP ApplyFunction(SEXP v, SEXP vectorPass,
 
         switch (TYPEOF(RFunVal)) {
             case STRSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(STRSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(STRSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, mySample, myBigSamp,
-                               myReps, stdFun, rho, nthResFun, m, sampSize,
+                               myReps, stdFun, rho, nthResFun, m, n_samp,
                                IsNamed, IsGmp, lenV, commonLen, STRSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } case CPLXSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(CPLXSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(CPLXSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, mySample, myBigSamp,
-                               myReps, stdFun, rho, nthResFun, m, sampSize,
+                               myReps, stdFun, rho, nthResFun, m, n_samp,
                                IsNamed, IsGmp, lenV, commonLen, CPLXSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } case RAWSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(RAWSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(RAWSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, mySample, myBigSamp,
-                               myReps, stdFun, rho, nthResFun, m, sampSize,
+                               myReps, stdFun, rho, nthResFun, m, n_samp,
                                IsNamed, IsGmp, lenV, commonLen, RAWSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } case LGLSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(LGLSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(LGLSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, mySample, myBigSamp,
-                               myReps, stdFun, rho, nthResFun, m, sampSize,
+                               myReps, stdFun, rho, nthResFun, m, n_samp,
                                IsNamed, IsGmp, lenV, commonLen, LGLSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } case INTSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(INTSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(INTSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, mySample, myBigSamp,
-                               myReps, stdFun, rho, nthResFun, m, sampSize,
+                               myReps, stdFun, rho, nthResFun, m, n_samp,
                                IsNamed, IsGmp, lenV, commonLen, INTSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } case REALSXP : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(REALSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(REALSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, mySample, myBigSamp,
-                               myReps, stdFun, rho, nthResFun, m, sampSize,
+                               myReps, stdFun, rho, nthResFun, m, n_samp,
                                IsNamed, IsGmp, lenV, commonLen, REALSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             } default : {
-                SEXP res = PROTECT(
-                    Rf_allocVector(VECSXP, sampSize * commonLen)
-                );
+                cpp11::sexp res = Rf_allocVector(VECSXP, n_samp * commonLen);
 
                 SampleApplyFun(res, v, vectorPass, mySample, myBigSamp,
-                               myReps, stdFun, rho, nthResFun, m, sampSize,
+                               myReps, stdFun, rho, nthResFun, m, n_samp,
                                IsNamed, IsGmp, lenV, commonLen, VECSXP);
 
-                SetDims(RFunVal, res, commonLen, sampSize);
-                UNPROTECT(1);
+                SetDims(RFunVal, res, commonLen, n_samp);
                 return res;
             }
         }
     } else {
-        SEXP myList = PROTECT(Rf_allocVector(VECSXP, sampSize));
+        cpp11::sexp myList = Rf_allocVector(VECSXP, n_samp);
         SampleApplyFun(myList, v, vectorPass, mySample, myBigSamp,
-                       myReps, stdFun, rho, nthResFun, m, sampSize,
+                       myReps, stdFun, rho, nthResFun, m, n_samp,
                        IsNamed, IsGmp, lenV);
-        UNPROTECT(1);
         return myList;
     }
 }
@@ -334,88 +288,81 @@ SEXP SampleCombPermApply(SEXP Rv, const std::vector<int> &vInt,
 
     switch (myType) {
         case VecType::Character : {
-            SEXP charVec = PROTECT(Rf_duplicate(Rv));
-            SEXP vectorPass = PROTECT(Rf_allocVector(STRSXP, m));
+            cpp11::sexp charVec = Rf_duplicate(Rv);
+            cpp11::sexp vectorPass = Rf_allocVector(STRSXP, m);
 
-            SEXP res = PROTECT(
-                ApplyFunction(charVec, vectorPass, mySample, myBigSamp,
-                              myReps, stdFun, rho, RFunVal, nthResFun,
-                              m, sampSize, IsNamed, IsGmp, n)
+            cpp11::sexp res = ApplyFunction(
+                charVec, vectorPass, mySample, myBigSamp, myReps, stdFun,
+                rho, RFunVal, nthResFun, m, sampSize, IsNamed, IsGmp, n
             );
 
             MpzClearVec(myBigSamp, sampSize, IsGmp);
-            UNPROTECT(3);
             return res;
         } case VecType::Complex : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(CPLXSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(CPLXSXP, m);
             Rcomplex* ptr_vec = COMPLEX(vectorPass);
 
             Rcomplex* cmplxVec = COMPLEX(Rv);
             std::vector<Rcomplex> vCmplx(cmplxVec, cmplxVec + n);
 
-            SEXP res = PROTECT(
-                ApplyFunction(vCmplx, vectorPass, ptr_vec, mySample,
-                              myBigSamp, myReps, stdFun, rho, RFunVal,
-                              nthResFun, m, sampSize, IsNamed, IsGmp, n)
+            cpp11::sexp res = ApplyFunction(
+                vCmplx, vectorPass, ptr_vec, mySample, myBigSamp, myReps,
+                stdFun, rho, RFunVal, nthResFun, m, sampSize, IsNamed,
+                IsGmp, n
             );
 
             MpzClearVec(myBigSamp, sampSize, IsGmp);
-            UNPROTECT(2);
             return res;
         } case VecType::Raw : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(RAWSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(RAWSXP, m);
             Rbyte* ptr_vec = RAW(vectorPass);
 
             Rbyte* rawVec = RAW(Rv);
             std::vector<Rbyte> vByte(rawVec, rawVec + n);
 
-            SEXP res = PROTECT(
-                ApplyFunction(vByte, vectorPass, ptr_vec, mySample,
-                              myBigSamp, myReps, stdFun, rho, RFunVal,
-                              nthResFun, m, sampSize, IsNamed, IsGmp, n)
+            cpp11::sexp res = ApplyFunction(
+                vByte, vectorPass, ptr_vec, mySample, myBigSamp, myReps,
+                stdFun, rho, RFunVal, nthResFun, m, sampSize, IsNamed,
+                IsGmp, n
             );
 
             MpzClearVec(myBigSamp, sampSize, IsGmp);
-            UNPROTECT(2);
             return res;
         } case VecType::Logical : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(LGLSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(LGLSXP, m);
             int* ptr_vec = LOGICAL(vectorPass);
 
-            SEXP res = PROTECT(
-                ApplyFunction(vInt, vectorPass, ptr_vec, mySample,
-                              myBigSamp, myReps, stdFun, rho, RFunVal,
-                              nthResFun, m, sampSize, IsNamed, IsGmp, n)
+            cpp11::sexp res = ApplyFunction(
+                vInt, vectorPass, ptr_vec, mySample, myBigSamp, myReps,
+                stdFun, rho, RFunVal, nthResFun, m, sampSize, IsNamed,
+                IsGmp, n
             );
 
             MpzClearVec(myBigSamp, sampSize, IsGmp);
-            UNPROTECT(2);
             return res;
         } case VecType::Integer : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(INTSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(INTSXP, m);
             int* ptr_vec = INTEGER(vectorPass);
 
-            SEXP res = PROTECT(
-                ApplyFunction(vInt, vectorPass, ptr_vec, mySample,
-                              myBigSamp, myReps, stdFun, rho, RFunVal,
-                              nthResFun, m, sampSize, IsNamed, IsGmp, n)
+            cpp11::sexp res = ApplyFunction(
+                vInt, vectorPass, ptr_vec, mySample, myBigSamp, myReps,
+                stdFun, rho, RFunVal, nthResFun, m, sampSize, IsNamed,
+                IsGmp, n
             );
 
             MpzClearVec(myBigSamp, sampSize, IsGmp);
-            UNPROTECT(2);
             return res;
         } default : {
-            SEXP vectorPass = PROTECT(Rf_allocVector(REALSXP, m));
+            cpp11::sexp vectorPass = Rf_allocVector(REALSXP, m);
             double* ptr_vec = REAL(vectorPass);
 
-            SEXP res = PROTECT(
-                ApplyFunction(vNum, vectorPass, ptr_vec, mySample,
-                              myBigSamp, myReps, stdFun, rho, RFunVal,
-                              nthResFun, m, sampSize, IsNamed, IsGmp, n)
+            cpp11::sexp res = ApplyFunction(
+                vNum, vectorPass, ptr_vec, mySample, myBigSamp, myReps,
+                stdFun, rho, RFunVal, nthResFun, m, sampSize, IsNamed,
+                IsGmp, n
             );
 
             MpzClearVec(myBigSamp, sampSize, IsGmp);
-            UNPROTECT(2);
             return res;
         }
     }

--- a/src/SamplePartitions.cpp
+++ b/src/SamplePartitions.cpp
@@ -219,7 +219,7 @@ SEXP SamplePartitions(SEXP Rv, SEXP Rm, SEXP RisRep, SEXP RFreqs,
                                       [](int i){return i > 0;});
 
     if (myType == VecType::Integer) {
-        SEXP res = PROTECT(Rf_allocMatrix(INTSXP, sampSize, part.width));
+        cpp11::sexp res = Rf_allocMatrix(INTSXP, sampSize, part.width);
         int* matInt = INTEGER(res);
 
         if (part.width == 1) {
@@ -233,10 +233,9 @@ SEXP SamplePartitions(SEXP Rv, SEXP Rm, SEXP RisRep, SEXP RFreqs,
                              strtLen, cap, part.isGmp);
         }
 
-        UNPROTECT(1);
         return res;
     } else {
-        SEXP res = PROTECT(Rf_allocMatrix(REALSXP, sampSize, part.width));
+        cpp11::sexp res = Rf_allocMatrix(REALSXP, sampSize, part.width);
         double* matNum = REAL(res);
 
         if (part.width == 1) {
@@ -250,7 +249,6 @@ SEXP SamplePartitions(SEXP Rv, SEXP Rm, SEXP RisRep, SEXP RFreqs,
                              strtLen, cap, part.isGmp);
         }
 
-        UNPROTECT(1);
         return res;
     }
 }

--- a/src/SetUpUtils.cpp
+++ b/src/SetUpUtils.cpp
@@ -537,10 +537,10 @@ void SetRandomSample(SEXP RindexVec, SEXP RNumSamp, int &sampSize,
                 cpp11::stop("n exceeds the maximum number of possible results");
             }
 
-            SEXP sample = PROTECT(Rf_lang3(baseSample,
-                                           Rf_ScalarReal(computedRows),
-                                           RNumSamp));
-            SEXP val = PROTECT(Rf_eval(sample, rho));
+            cpp11::sexp sample = Rf_lang3(baseSample,
+                                          Rf_ScalarReal(computedRows),
+                                          RNumSamp);
+            cpp11::sexp val = Rf_eval(sample, rho);
             mySample.resize(sampSize);
 
             if (computedRows < std::numeric_limits<int>::max()) {
@@ -557,7 +557,6 @@ void SetRandomSample(SEXP RindexVec, SEXP RNumSamp, int &sampSize,
                 }
             }
 
-            UNPROTECT(2);
         }
     } else {
         if (IsGmp) {
@@ -666,7 +665,7 @@ void SetSampleNames(SEXP object, bool IsGmp, int sampSize,
                     mpz_t *const myBigSamp, SEXP colNames,
                     int xtraDims) {
 
-    SEXP myNames = PROTECT(Rf_allocVector(STRSXP, sampSize));
+    cpp11::sexp myNames = Rf_allocVector(STRSXP, sampSize);
 
     if (IsGmp) {
         for (int i = 0; i < sampSize; ++i) {
@@ -689,59 +688,54 @@ void SetSampleNames(SEXP object, bool IsGmp, int sampSize,
     }
 
     if (Rf_isMatrix(object) || Rf_isArray(object)) {
-        SEXP dimNames = PROTECT(Rf_allocVector(VECSXP, 1 + xtraDims));
+        cpp11::sexp dimNames = Rf_allocVector(VECSXP, 1 + xtraDims);
         SET_VECTOR_ELT(dimNames, 0, myNames);
         if (xtraDims) SET_VECTOR_ELT(dimNames, xtraDims, colNames);
         Rf_setAttrib(object, R_DimNamesSymbol, dimNames);
-        UNPROTECT(2 + (xtraDims > 0));
     } else if (Rf_isList(object) || Rf_isVector(object)) {
         Rf_setAttrib(object, R_NamesSymbol, myNames);
-        UNPROTECT(1);
     }
 }
 
 SEXP GetIntVec(const std::vector<int> &v) {
     const int size = v.size();
-    SEXP res = PROTECT(Rf_allocVector(INTSXP, size));
+    cpp11::sexp res = Rf_allocVector(INTSXP, size);
     int* ptrRes = INTEGER(res);
 
     for (int i = 0; i < size; ++i) {
         ptrRes[i] = v[i];
     }
 
-    UNPROTECT(1);
     return res;
 }
 
 SEXP GetDblVec(const std::vector<double> &v) {
     const int size = v.size();
-    SEXP res = PROTECT(Rf_allocVector(REALSXP, size));
+    cpp11::sexp res = Rf_allocVector(REALSXP, size);
     double* ptrRes = REAL(res);
 
     for (int i = 0; i < size; ++i) {
         ptrRes[i] = v[i];
     }
 
-    UNPROTECT(1);
     return res;
 }
 
 SEXP GetInt64Vec(const std::vector<std::int64_t> &v) {
     const int size = v.size();
-    SEXP res = PROTECT(Rf_allocVector(REALSXP, size));
+    cpp11::sexp res = Rf_allocVector(REALSXP, size);
     double* ptrRes = REAL(res);
 
     for (int i = 0; i < size; ++i) {
         ptrRes[i] = v[i];
     }
 
-    UNPROTECT(1);
     return res;
 }
 
 void SetIntNames(SEXP res, std::size_t myRange, int myMin, int myMax) {
 
-    SEXP myNames  = PROTECT(Rf_allocVector(INTSXP, myRange));
+    cpp11::sexp myNames  = Rf_allocVector(INTSXP, myRange);
     int* ptrNames = INTEGER(myNames);
 
     for (int k = 0, retM = myMin; retM <= myMax; ++retM, ++k) {
@@ -755,7 +749,7 @@ void SetDblNames(SEXP res, std::size_t myRange,
                  double myMin, double myMax) {
 
     double retM = myMin;
-    SEXP myNames  = PROTECT(Rf_allocVector(REALSXP, myRange));
+    cpp11::sexp myNames  = Rf_allocVector(REALSXP, myRange);
     double* ptrNames = REAL(myNames);
 
     for (int k = 0; retM <= myMax; ++retM, ++k) {
@@ -768,7 +762,7 @@ void SetDblNames(SEXP res, std::size_t myRange,
 void SetDblNames(SEXP res, const std::vector<double> &myNums) {
 
     const int size = myNums.size();
-    SEXP myNames  = PROTECT(Rf_allocVector(REALSXP, size));
+    cpp11::sexp myNames  = Rf_allocVector(REALSXP, size);
     double* ptrNames = REAL(myNames);
 
     for (int k = 0; k < size; ++k) {

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -6,10 +6,10 @@
 #include <R_ext/Visibility.h>
 
 // CartesianContainer.cpp
-SEXP ComboGridCpp(SEXP RList, SEXP RIsRep);
-extern "C" SEXP _RcppAlgos_ComboGridCpp(SEXP RList, SEXP RIsRep) {
+SEXP ComboGridCpp(cpp11::list RList, bool IsRep);
+extern "C" SEXP _RcppAlgos_ComboGridCpp(SEXP RList, SEXP IsRep) {
   BEGIN_CPP11
-    return cpp11::as_sexp(ComboGridCpp(cpp11::as_cpp<cpp11::decay_t<SEXP>>(RList), cpp11::as_cpp<cpp11::decay_t<SEXP>>(RIsRep)));
+    return cpp11::as_sexp(ComboGridCpp(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(RList), cpp11::as_cpp<cpp11::decay_t<bool>>(IsRep)));
   END_CPP11
 }
 // CheckReturn.cpp


### PR DESCRIPTION
Replaced all occurrences of:

```c++
SEXP var = PROTECT(...);
some code
UNPROTECT(1);
return res;`
```

 with:

 ```c++
cpp11::sexp var = ...
some code
return res;
``` 