### PR TITLE
Fix compositions count freqs target

### DIFF
--- a/ai_git_helpers/commit_msg.py
+++ b/ai_git_helpers/commit_msg.py
@@ -29,7 +29,7 @@ ALLOWED_PREFIXES = {
     "ci"
 }
 
-MODEL = os.getenv("AI_REVIEW_MODEL", "gpt-5.2")
+MODEL = os.getenv("AI_REVIEW_MODEL", "gpt-5.5")
 MAX_OUTPUT_TOKENS = 200
 TEMPERATURE = 0.2
 SUBJECT_MAX = 72
@@ -294,8 +294,7 @@ def main():
                 context=context
             )},
         ],
-        max_output_tokens=MAX_OUTPUT_TOKENS,
-        temperature=TEMPERATURE,
+        max_output_tokens=MAX_OUTPUT_TOKENS
     )
 
     message = (response.output_text or "").strip()

--- a/ai_git_helpers/news.py
+++ b/ai_git_helpers/news.py
@@ -4,7 +4,7 @@ import os
 import sys
 from openai import OpenAI
 
-MODEL = "gpt-5.2"
+MODEL = os.getenv("AI_REVIEW_MODEL", "gpt-5.5")
 
 SYSTEM_PROMPT = """
 You are helping maintain the R package RcppAlgos. You are an expert C++

--- a/ai_git_helpers/pr_summary.py
+++ b/ai_git_helpers/pr_summary.py
@@ -4,7 +4,7 @@ import os
 import sys
 from openai import OpenAI
 
-MODEL = "gpt-5.2"
+MODEL = os.getenv("AI_REVIEW_MODEL", "gpt-5.5")
 
 SYSTEM_PROMPT = """
 You are helping maintain the R package RcppAlgos. You are an expert C++

--- a/ai_git_helpers/review.py
+++ b/ai_git_helpers/review.py
@@ -12,9 +12,8 @@ from typing import Optional
 
 MAX_FILE_BYTES = 200_000
 MAX_DIFF_BYTES_TOTAL = 400_000
-MODEL = os.getenv("AI_REVIEW_MODEL", "gpt-5.2")
+MODEL = os.getenv("AI_REVIEW_MODEL", "gpt-5.5")
 MAX_OUTPUT_TOKENS = 4000
-TEMPERATURE = 0.2
 
 SYSTEM_PROMPT = """\
 You are an expert C++ software engineer with deep knowledge of
@@ -467,8 +466,7 @@ def main():
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": user_content},
         ],
-        max_output_tokens=MAX_OUTPUT_TOKENS,
-        temperature=TEMPERATURE,
+        max_output_tokens=MAX_OUTPUT_TOKENS
     )
 
     text = (response.output_text or "").strip()

--- a/src/PartitionsCount.cpp
+++ b/src/PartitionsCount.cpp
@@ -629,7 +629,9 @@ int PartitionsCount(const std::vector<int> &Reps,
         // N.B. With PartitionType::Multiset we use the default
         // IsComp = false. Below, we set IsComp = true
         part.count = part.solnExist ?
-            CountPartsMultiset(Reps, part.startZ, true, part.isWeak) : 0;
+            CountPartsMultiset(
+                Reps, part.startZ, true, !part.includeZero || part.isWeak
+            ) : 0;
         return 1;
     } else if (part.ptype == PartitionType::PrmMultiset) {
         // See note above under CompMultiset

--- a/src/PartitionsCount.cpp
+++ b/src/PartitionsCount.cpp
@@ -628,10 +628,19 @@ int PartitionsCount(const std::vector<int> &Reps,
     } else if (part.ptype == PartitionType::CompMultiset) {
         // N.B. With PartitionType::Multiset we use the default
         // IsComp = false. Below, we set IsComp = true
+
+        // CountPartsMultiset() uses the final flag to decide whether zeros
+        // should participate in the permutation count. When the user supplied
+        // zero, this agrees with the usual weak/non-weak distinction. When
+        // zero was not supplied, any zeros in startZ are only internal padding
+        // introduced by the partition counting machinery, and the
+        // corresponding compositions should be counted as fixed-length
+        // arrangements. In that case, use the weak-style permutation count
+        // so NumPermsWithRep() does not drop those padded positions.
+        const bool countZeros = !part.includeZero || part.isWeak;
+
         part.count = part.solnExist ?
-            CountPartsMultiset(
-                Reps, part.startZ, true, !part.includeZero || part.isWeak
-            ) : 0;
+            CountPartsMultiset(Reps, part.startZ, true, countZeros) : 0;
         return 1;
     } else if (part.ptype == PartitionType::PrmMultiset) {
         // See note above under CompMultiset

--- a/tests/testthat/testPermuteGeneral.R
+++ b/tests/testthat/testPermuteGeneral.R
@@ -449,4 +449,12 @@ test_that("permuteCount produces correct results under partition constraints", {
         ),
         compositionsCount(table(c(rep(0L, 5), 1:100)), weak = TRUE)
     )
+
+    expect_equal(
+        permuteCount(
+            1:15, 8, freqs = rep(5:1, each = 3), constraintFun = "sum",
+            comparisonFun = "==", limitConstraints = 40
+        ),
+        compositionsCount(1:15, 8, freqs = rep(5:1, each = 3), target = 40)
+    )
 })


### PR DESCRIPTION
## Summary

This PR fixes a counting bug in `compositionsCount()` for multiset inputs with repeated frequencies, a fixed length, and a target constraint when the input does not include zero.

Previously, the following equivalent counting paths returned different results:

```r
permuteCount(
    1:15, 8,
    freqs = rep(5:1, each = 3),
    constraintFun = "sum",
    comparisonFun = "==",
    limitConstraints = 40
)
# 12527578

compositionsCount(
    1:15, 8,
    freqs = rep(5:1, each = 3),
    target = 40
)
# previously 3262902
# now 12527578
```

The fix updates the multiset composition/partition counting path so the weak-counting flag is set correctly when zero is not included, or when the count is explicitly weak.

## Changes

* Fixed the affected multiset counting condition.
* Added a regression test covering the mismatch above.
* Updated internal AI helper scripts to use the newer default model and omit unsupported `temperature` parameters.

## Notes

No API changes are introduced. Existing code remains source-compatible, but counts for affected cases may change from the previous incorrect value to the corrected value.
